### PR TITLE
enhance remote setup deployment and improve QQ multi-image replies

### DIFF
--- a/model_inference/src/llm_api.rs
+++ b/model_inference/src/llm_api.rs
@@ -292,6 +292,21 @@ impl LLMAPI {
                 },
                 _ => parse_chat_completions_sse_response(&response_text),
             } {
+                if matches!(self.api_style, LlmApiStyle::OpenAiResponsesMessageCompat)
+                    && message.parts.is_empty()
+                    && message.tool_calls.is_empty()
+                    && message
+                        .reasoning_content
+                        .as_deref()
+                        .map(|content| content.trim().is_empty())
+                        .unwrap_or(true)
+                {
+                    warn!(
+                        "[LLMAPI] Responses message-compatible SSE response has no parsed content: model={} response={}",
+                        self.model_name,
+                        response_text,
+                    );
+                }
                 return Ok(self.tag_response_api_style(message));
             }
         }

--- a/model_inference/src/llm_api.rs
+++ b/model_inference/src/llm_api.rs
@@ -329,6 +329,23 @@ impl LLMAPI {
             },
             _ => parse_chat_completions_response(&api_resp),
         };
+        if matches!(self.api_style, LlmApiStyle::OpenAiResponsesMessageCompat)
+            && parsed_message.as_ref().is_some_and(|message| {
+                message.parts.is_empty()
+                    && message.tool_calls.is_empty()
+                    && message
+                        .reasoning_content
+                        .as_deref()
+                        .map(|content| content.trim().is_empty())
+                        .unwrap_or(true)
+            })
+        {
+            warn!(
+                "[LLMAPI] Responses message-compatible response has no parsed content: model={} output={}",
+                self.model_name,
+                api_resp.get("output").unwrap_or(&Value::Null),
+            );
+        }
         parsed_message
             .map(|message| self.tag_response_api_style(message))
             .ok_or_else(|| RequestError::NonRetryable {

--- a/src/api/chat.rs
+++ b/src/api/chat.rs
@@ -178,6 +178,8 @@ pub struct ChatHistoryRecord {
     pub agent_avatar_url: Option<String>,
     pub role: String,
     pub content: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parts: Vec<MessagePart>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_content: Option<String>,
     pub timestamp: String,
@@ -978,7 +980,7 @@ fn sanitize_messages(messages: Vec<LLMMessage>) -> Vec<LLMMessage> {
         .filter(|message| {
             let has_content = message.content_text_owned().is_some_and(|text| !text.trim().is_empty());
             let has_reasoning = message.reasoning_content.as_deref().is_some_and(|text| !text.trim().is_empty());
-            has_content || has_reasoning || !message.tool_calls.is_empty()
+            has_content || has_reasoning || !message.parts.is_empty() || !message.tool_calls.is_empty()
         })
         .collect()
 }
@@ -1026,6 +1028,7 @@ fn persist_chat_records(
             agent_avatar_url: agent_snapshot.avatar_url.clone(),
             role: "user".to_string(),
             content: user_message.content_text_owned().unwrap_or_default(),
+            parts: user_message.parts.clone(),
             reasoning_content: None,
             timestamp: now.clone(),
             stream_index: None,
@@ -1054,6 +1057,7 @@ fn persist_chat_records(
             agent_avatar_url: agent_snapshot.avatar_url.clone(),
             role: role.to_string(),
             content: message.content_text_owned().unwrap_or_default(),
+            parts: message.parts.clone(),
             reasoning_content: message.reasoning_content.clone(),
             timestamp: now.clone(),
             stream_index: None,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -126,6 +126,10 @@ pub fn build_router(state: Arc<AppState>, broadcast: WsBroadcast, canonical_loca
             Router::with_path("setup")
                 .get(setup_wizard::get_setup_status)
                 .post(setup_wizard::post_execute_setup)
+                .push(
+                    Router::with_path("detailed-install-command")
+                        .post(setup_wizard::post_generate_detailed_install_command),
+                )
                 .push(Router::with_path("status").get(setup_wizard::get_setup_status))
                 .push(Router::with_path("environment").get(setup_wizard::get_environment_info))
                 .push(Router::with_path("progress").get(setup_wizard::stream_setup_progress))

--- a/src/api/setup_wizard.rs
+++ b/src/api/setup_wizard.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 use crate::api::config::{now_rfc3339, ok_response, render_internal_error};
 use crate::api::state::AppState;
 use crate::setup_orchestrator::{
-    DetailedSetupConfig, ImsBotAdapterSetupConfig, LlmSetupConfig, SetupOptions, SetupOrchestrator, SetupRole,
+    generate_detailed_install_command, DetailedSetupConfig, ImsBotAdapterSetupConfig, LlmSetupConfig, SetupOptions,
+    SetupOrchestrator, SetupRole,
 };
 use zihuan_core::setup_wizard::{clear_setup_wizard_state, load_setup_wizard_state, save_setup_wizard_state};
 
@@ -37,6 +38,31 @@ pub enum SetupMode {
 pub struct ExecuteSetupResponse {
     pub accepted: bool,
     pub task_id: String,
+}
+
+#[derive(Deserialize)]
+pub struct GenerateDetailedInstallCommandRequest {
+    pub detailed_config: DetailedSetupConfig,
+}
+
+#[handler]
+pub async fn post_generate_detailed_install_command(req: &mut Request, res: &mut Response) {
+    let body: GenerateDetailedInstallCommandRequest = match req.parse_json().await {
+        Ok(body) => body,
+        Err(err) => {
+            res.status_code(StatusCode::BAD_REQUEST);
+            res.render(Json(serde_json::json!({ "error": err.to_string() })));
+            return;
+        }
+    };
+
+    match generate_detailed_install_command(&body.detailed_config) {
+        Ok(command) => res.render(Json(command)),
+        Err(error) => {
+            res.status_code(StatusCode::BAD_REQUEST);
+            res.render(Json(serde_json::json!({ "error": error })));
+        }
+    }
 }
 
 #[handler]

--- a/src/api/setup_wizard.rs
+++ b/src/api/setup_wizard.rs
@@ -180,7 +180,7 @@ pub async fn post_execute_setup(req: &mut Request, res: &mut Response, depot: &m
             SetupMode::Skip => Ok(()),
         };
         if let Err(err) = result {
-            log::warn!("[setup_orchestrator] task {} failed: {}", task_id_for_spawn, err);
+            log::error!("[setup_orchestrator] task {} failed: {}", task_id_for_spawn, err);
             orchestrator.emit("failed", "error", &err, None);
         }
         // Keep the broadcast channel alive for 60s so late SSE clients can still connect.

--- a/src/setup_orchestrator/mod.rs
+++ b/src/setup_orchestrator/mod.rs
@@ -412,7 +412,7 @@ pub fn generate_detailed_install_command(config: &DetailedSetupConfig) -> Result
 
     let compose = detailed_compose(config);
     let install_command = match &config.install_method {
-        DetailedInstallMethod::Docker => docker_install_command(&compose),
+        DetailedInstallMethod::Docker => docker_install_command(config, &compose),
         DetailedInstallMethod::Binary => binary_install_command(config, &compose),
     };
 
@@ -422,18 +422,20 @@ pub fn generate_detailed_install_command(config: &DetailedSetupConfig) -> Result
     })
 }
 
-fn docker_install_command(compose: &str) -> String {
+fn docker_install_command(config: &DetailedSetupConfig, compose: &str) -> String {
     let compose_base64 = base64_encode(compose.as_bytes());
+    let create_data_dirs = docker_data_directory_command(config);
     format!(
-        "# Run on the target Linux machine\nmkdir -p ~/zihuan-next-install && cd ~/zihuan-next-install\nprintf '%s' '{compose_base64}' | base64 -d > docker-compose.yaml\ndocker compose -f docker-compose.yaml up -d"
+        "# Run on the target Linux machine\nmkdir -p ~/zihuan-next-install && cd ~/zihuan-next-install\n{create_data_dirs}\nprintf '%s' '{compose_base64}' | base64 -d > docker-compose.yaml\ndocker compose -f docker-compose.yaml up -d"
     )
 }
 
 fn binary_install_command(config: &DetailedSetupConfig, compose: &str) -> String {
     let compose_base64 = base64_encode(compose.as_bytes());
     let services = detailed_install_services(config).join(" ");
+    let create_data_dirs = docker_data_directory_command(config);
     format!(
-        "# Run on the target Linux x86_64 machine\nsudo apt-get update\nsudo apt-get install -y build-essential pkg-config libssl-dev git nodejs npm docker.io docker-compose-plugin\ngit clone --recurse-submodules https://github.com/FredYakumo/zihuan-next.git ~/zihuan-next\ncd ~/zihuan-next\ncorepack enable && corepack prepare pnpm@10.22.0 --activate\ncd webui && pnpm install --frozen-lockfile && pnpm run build\ncd .. && cargo build --release\nmkdir -p ~/zihuan-next-install && cd ~/zihuan-next-install\nprintf '%s' '{compose_base64}' | base64 -d > docker-compose.yaml\ndocker compose -f docker-compose.yaml up -d {services}\n# Start Zihuan Next after importing the generated connections JSON:\n~/zihuan-next/target/release/zihuan_next --host 0.0.0.0 --port 9951"
+        "# Run on the target Linux x86_64 machine\nsudo apt-get update\nsudo apt-get install -y build-essential pkg-config libssl-dev git nodejs npm docker.io docker-compose-plugin\ngit clone --recurse-submodules https://github.com/FredYakumo/zihuan-next.git ~/zihuan-next\ncd ~/zihuan-next\ncorepack enable && corepack prepare pnpm@10.22.0 --activate\ncd webui && pnpm install --frozen-lockfile && pnpm run build\ncd .. && cargo build --release\nmkdir -p ~/zihuan-next-install && cd ~/zihuan-next-install\n{create_data_dirs}\nprintf '%s' '{compose_base64}' | base64 -d > docker-compose.yaml\ndocker compose -f docker-compose.yaml up -d {services}\n# Start Zihuan Next after importing the generated connections JSON:\n~/zihuan-next/target/release/zihuan_next --host 0.0.0.0 --port 9951"
     )
 }
 
@@ -577,7 +579,18 @@ async fn run_detailed_docker(config: &DetailedSetupConfig, services: &[&str]) ->
         return Err("Docker Compose is unavailable. Install Docker Desktop or Docker Compose, then retry.".to_string());
     }
     let compose_path = detailed_compose_path();
-    if let Some(parent) = compose_path.parent() { tokio::fs::create_dir_all(parent).await.map_err(|err| err.to_string())?; }
+    let compose_dir = compose_path
+        .parent()
+        .ok_or_else(|| "Detailed Docker Compose path has no parent directory".to_string())?;
+    tokio::fs::create_dir_all(compose_dir)
+        .await
+        .map_err(|err| format!("Failed to create Docker Compose directory: {err}"))?;
+    for data_dir in detailed_data_dirs(config) {
+        let data_dir = resolve_compose_data_dir(compose_dir, &data_dir);
+        tokio::fs::create_dir_all(&data_dir)
+            .await
+            .map_err(|err| format!("Failed to create container data directory {}: {err}", data_dir.display()))?;
+    }
     tokio::fs::write(&compose_path, detailed_compose(config)).await.map_err(|err| err.to_string())?;
     let output = tokio::process::Command::new("docker")
         .arg("compose").arg("-f").arg(&compose_path).arg("up").arg("-d").args(services)
@@ -620,29 +633,83 @@ async fn run_detailed_binary(_config: &DetailedSetupConfig, services: &[&str]) -
 
 fn detailed_compose_path() -> PathBuf { zihuan_core::system_config::app_data_dir().join("zihuan-next_aibot").join("detailed-compose.yaml") }
 
+fn detailed_data_dirs(config: &DetailedSetupConfig) -> Vec<String> {
+    let mut data_dirs = Vec::new();
+    if config.relational.enabled
+        && config.relational.source == DetailedComponentSource::Install
+        && config.relational.database_type == "mysql"
+    {
+        data_dirs.push(config.relational.deployment.data_dir.clone());
+    }
+    if config.rustfs.enabled && config.rustfs.source == DetailedComponentSource::Install {
+        data_dirs.push(config.rustfs.deployment.data_dir.clone());
+    }
+    if config.search.enabled && config.search.source == DetailedComponentSource::Install {
+        data_dirs.push(config.search.deployment.data_dir.clone());
+    }
+    if config.redis.enabled && config.redis.source == DetailedComponentSource::Install {
+        data_dirs.push(config.redis.deployment.data_dir.clone());
+    }
+    data_dirs
+}
+
+fn compose_bind_source(data_dir: &str) -> String {
+    let data_dir = data_dir.trim();
+    if data_dir.starts_with('.') || Path::new(data_dir).is_absolute() {
+        return data_dir.to_string();
+    }
+    format!("./{data_dir}")
+}
+
+fn resolve_compose_data_dir(compose_dir: &Path, data_dir: &str) -> PathBuf {
+    let bind_source = compose_bind_source(data_dir);
+    let path = Path::new(&bind_source);
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    compose_dir.join(path.strip_prefix(".").unwrap_or(path))
+}
+
+fn docker_data_directory_command(config: &DetailedSetupConfig) -> String {
+    let data_dirs = detailed_data_dirs(config);
+    if data_dirs.is_empty() {
+        return String::new();
+    }
+    let data_dirs = data_dirs
+        .iter()
+        .map(|data_dir| shell_quote(&compose_bind_source(data_dir)))
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!("mkdir -p -- {data_dirs}")
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\\"'\\\"'"))
+}
+
 fn detailed_compose(config: &DetailedSetupConfig) -> String {
     let mut services = String::from("services:\n");
     if config.relational.enabled && config.relational.source == DetailedComponentSource::Install && config.relational.database_type == "mysql" {
         let d = &config.relational.deployment;
-        services.push_str(&format!("  mysql:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:3306\"]\n    volumes: [\"{}:/var/lib/mysql\"]\n    environment:\n      MYSQL_ROOT_PASSWORD: {}\n      MYSQL_DATABASE: {}\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&d.data_dir), yaml_quote(&config.relational.password), yaml_quote(&config.relational.database)));
+        services.push_str(&format!("  mysql:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:3306\"]\n    volumes: [\"{}:/var/lib/mysql\"]\n    environment:\n      MYSQL_ROOT_PASSWORD: {}\n      MYSQL_DATABASE: {}\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&compose_bind_source(&d.data_dir)), yaml_quote(&config.relational.password), yaml_quote(&config.relational.database)));
     }
-    if config.rustfs.enabled && config.rustfs.source == DetailedComponentSource::Install { let d = &config.rustfs.deployment; services.push_str(&format!("  rustfs:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:9000\"]\n    volumes: [\"{}:/data\"]\n    environment:\n      RUSTFS_ACCESS_KEY: {}\n      RUSTFS_SECRET_KEY: {}\n    command: [\"--console-enable\", \"/data\"]\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&d.data_dir), yaml_quote(&config.rustfs.access_key), yaml_quote(&config.rustfs.secret_key))); }
+    if config.rustfs.enabled && config.rustfs.source == DetailedComponentSource::Install { let d = &config.rustfs.deployment; services.push_str(&format!("  rustfs:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:9000\"]\n    volumes: [\"{}:/data\"]\n    environment:\n      RUSTFS_ACCESS_KEY: {}\n      RUSTFS_SECRET_KEY: {}\n    command: [\"--console-enable\", \"/data\"]\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&compose_bind_source(&d.data_dir)), yaml_quote(&config.rustfs.access_key), yaml_quote(&config.rustfs.secret_key))); }
     if config.search.enabled && config.search.source == DetailedComponentSource::Install {
         let d = &config.search.deployment;
-        if config.search.search_type == "elasticsearch" { services.push_str(&format!("  elasticsearch:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:9200\"]\n    volumes: [\"{}:/usr/share/elasticsearch/data\"]\n    environment:\n      discovery.type: single-node\n      xpack.security.enabled: 'true'\n      ELASTIC_PASSWORD: {}\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&d.data_dir), yaml_quote(config.search.password.as_deref().unwrap_or_default()))); }
+        if config.search.search_type == "elasticsearch" { services.push_str(&format!("  elasticsearch:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:9200\"]\n    volumes: [\"{}:/usr/share/elasticsearch/data\"]\n    environment:\n      discovery.type: single-node\n      xpack.security.enabled: 'true'\n      ELASTIC_PASSWORD: {}\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&compose_bind_source(&d.data_dir)), yaml_quote(config.search.password.as_deref().unwrap_or_default()))); }
         else {
             let authentication = if config.expose_public_access {
                 format!("      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'false'\n      AUTHENTICATION_APIKEY_ENABLED: 'true'\n      AUTHENTICATION_APIKEY_ALLOWED_KEYS: {}\n", yaml_quote(config.search.api_key.as_deref().unwrap_or_default()))
             } else {
                 "      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'\n".to_string()
             };
-            services.push_str(&format!("  weaviate:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:8080\"]\n    volumes: [\"{}:/var/lib/weaviate\"]\n    environment:\n{}      DEFAULT_VECTORIZER_MODULE: none\n      CLUSTER_HOSTNAME: node1\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&d.data_dir), authentication));
+            services.push_str(&format!("  weaviate:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:8080\"]\n    volumes: [\"{}:/var/lib/weaviate\"]\n    environment:\n{}      DEFAULT_VECTORIZER_MODULE: none\n      CLUSTER_HOSTNAME: node1\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&compose_bind_source(&d.data_dir)), authentication));
         }
     }
     if config.redis.enabled && config.redis.source == DetailedComponentSource::Install {
         let d = &config.redis.deployment;
         let command = if config.expose_public_access { format!("    command: [\"redis-server\", \"--requirepass\", {}]\n", yaml_quote(config.redis.password.as_deref().unwrap_or_default())) } else { String::new() };
-        services.push_str(&format!("  redis:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:6379\"]\n    volumes: [\"{}:/data\"]\n{}", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&d.data_dir), command));
+        services.push_str(&format!("  redis:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:6379\"]\n    volumes: [\"{}:/data\"]\n{}", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&compose_bind_source(&d.data_dir)), command));
     }
     services
 }

--- a/src/setup_orchestrator/mod.rs
+++ b/src/setup_orchestrator/mod.rs
@@ -691,31 +691,35 @@ fn detailed_compose(config: &DetailedSetupConfig) -> String {
     let mut services = String::from("services:\n");
     if config.relational.enabled && config.relational.source == DetailedComponentSource::Install && config.relational.database_type == "mysql" {
         let d = &config.relational.deployment;
-        services.push_str(&format!("  mysql:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:3306\"]\n    volumes: [\"{}:/var/lib/mysql\"]\n    environment:\n      MYSQL_ROOT_PASSWORD: {}\n      MYSQL_DATABASE: {}\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&compose_bind_source(&d.data_dir)), yaml_quote(&config.relational.password), yaml_quote(&config.relational.database)));
+        services.push_str(&format!("  mysql:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:3306\"]\n    volumes: [{}]\n    environment:\n      MYSQL_ROOT_PASSWORD: {}\n      MYSQL_DATABASE: {}\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, compose_bind_mount(&d.data_dir, "/var/lib/mysql"), yaml_quote(&config.relational.password), yaml_quote(&config.relational.database)));
     }
-    if config.rustfs.enabled && config.rustfs.source == DetailedComponentSource::Install { let d = &config.rustfs.deployment; services.push_str(&format!("  rustfs:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:9000\"]\n    volumes: [\"{}:/data\"]\n    environment:\n      RUSTFS_ACCESS_KEY: {}\n      RUSTFS_SECRET_KEY: {}\n    command: [\"--console-enable\", \"/data\"]\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&compose_bind_source(&d.data_dir)), yaml_quote(&config.rustfs.access_key), yaml_quote(&config.rustfs.secret_key))); }
+    if config.rustfs.enabled && config.rustfs.source == DetailedComponentSource::Install { let d = &config.rustfs.deployment; services.push_str(&format!("  rustfs:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:9000\"]\n    volumes: [{}]\n    environment:\n      RUSTFS_ACCESS_KEY: {}\n      RUSTFS_SECRET_KEY: {}\n    command: [\"--console-enable\", \"/data\"]\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, compose_bind_mount(&d.data_dir, "/data"), yaml_quote(&config.rustfs.access_key), yaml_quote(&config.rustfs.secret_key))); }
     if config.search.enabled && config.search.source == DetailedComponentSource::Install {
         let d = &config.search.deployment;
-        if config.search.search_type == "elasticsearch" { services.push_str(&format!("  elasticsearch:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:9200\"]\n    volumes: [\"{}:/usr/share/elasticsearch/data\"]\n    environment:\n      discovery.type: single-node\n      xpack.security.enabled: 'true'\n      ELASTIC_PASSWORD: {}\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&compose_bind_source(&d.data_dir)), yaml_quote(config.search.password.as_deref().unwrap_or_default()))); }
+        if config.search.search_type == "elasticsearch" { services.push_str(&format!("  elasticsearch:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:9200\"]\n    volumes: [{}]\n    environment:\n      discovery.type: single-node\n      xpack.security.enabled: 'true'\n      ELASTIC_PASSWORD: {}\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, compose_bind_mount(&d.data_dir, "/usr/share/elasticsearch/data"), yaml_quote(config.search.password.as_deref().unwrap_or_default()))); }
         else {
             let authentication = if config.expose_public_access {
                 format!("      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'false'\n      AUTHENTICATION_APIKEY_ENABLED: 'true'\n      AUTHENTICATION_APIKEY_ALLOWED_KEYS: {}\n", yaml_quote(config.search.api_key.as_deref().unwrap_or_default()))
             } else {
                 "      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'\n".to_string()
             };
-            services.push_str(&format!("  weaviate:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:8080\"]\n    volumes: [\"{}:/var/lib/weaviate\"]\n    environment:\n{}      DEFAULT_VECTORIZER_MODULE: none\n      CLUSTER_HOSTNAME: node1\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&compose_bind_source(&d.data_dir)), authentication));
+            services.push_str(&format!("  weaviate:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:8080\"]\n    volumes: [{}]\n    environment:\n{}      DEFAULT_VECTORIZER_MODULE: none\n      CLUSTER_HOSTNAME: node1\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, compose_bind_mount(&d.data_dir, "/var/lib/weaviate"), authentication));
         }
     }
     if config.redis.enabled && config.redis.source == DetailedComponentSource::Install {
         let d = &config.redis.deployment;
         let command = if config.expose_public_access { format!("    command: [\"redis-server\", \"--requirepass\", {}]\n", yaml_quote(config.redis.password.as_deref().unwrap_or_default())) } else { String::new() };
-        services.push_str(&format!("  redis:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:6379\"]\n    volumes: [\"{}:/data\"]\n{}", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&compose_bind_source(&d.data_dir)), command));
+        services.push_str(&format!("  redis:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:6379\"]\n    volumes: [{}]\n{}", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, compose_bind_mount(&d.data_dir, "/data"), command));
     }
     services
 }
 
 fn yaml_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
+}
+
+fn compose_bind_mount(data_dir: &str, container_path: &str) -> String {
+    yaml_quote(&format!("{}:{container_path}", compose_bind_source(data_dir)))
 }
 
 async fn save_detailed_connections(config: &DetailedSetupConfig) -> Result<(), String> {

--- a/src/setup_orchestrator/mod.rs
+++ b/src/setup_orchestrator/mod.rs
@@ -6,7 +6,7 @@ use tokio::sync::broadcast;
 
 use zihuan_core::setup_wizard::{load_setup_wizard_state, save_setup_wizard_state};
 use storage_handler::{
-    ensure_collection_schema, ensure_elasticsearch_index, ConnectionKind, ElasticsearchConnection, ElasticsearchRef,
+    ensure_collection_schema, ensure_elasticsearch_index, ConnectionConfig, ConnectionKind, ElasticsearchConnection, ElasticsearchRef,
     MysqlConnection, RedisConnection, RustfsConnection, SqliteConnection, WeaviateConnection,
 };
 use zihuan_core::weaviate::{WeaviateCollectionSchema, WeaviateRef};
@@ -31,21 +31,21 @@ pub struct SetupOrchestrator {
     task_id: String,
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DetailedInstallMethod {
     Docker,
     Binary,
 }
 
-#[derive(Clone, Deserialize, PartialEq)]
+#[derive(Clone, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DetailedComponentSource {
     Install,
     Existing,
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct DetailedDeploymentConfig {
     pub image: String,
     pub port: u16,
@@ -54,7 +54,7 @@ pub struct DetailedDeploymentConfig {
     pub restart_policy: String,
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct DetailedRelationalSetupConfig {
     pub enabled: bool,
     pub source: DetailedComponentSource,
@@ -70,7 +70,7 @@ pub struct DetailedRelationalSetupConfig {
     pub acquire_timeout_secs: u64,
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct DetailedRustfsSetupConfig {
     pub enabled: bool,
     pub source: DetailedComponentSource,
@@ -84,7 +84,7 @@ pub struct DetailedRustfsSetupConfig {
     pub path_style: bool,
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct DetailedSearchSetupConfig {
     pub enabled: bool,
     pub source: DetailedComponentSource,
@@ -98,7 +98,7 @@ pub struct DetailedSearchSetupConfig {
     pub vector_dimensions: usize,
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct DetailedRedisSetupConfig {
     pub enabled: bool,
     pub source: DetailedComponentSource,
@@ -108,13 +108,22 @@ pub struct DetailedRedisSetupConfig {
     pub password: Option<String>,
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct DetailedSetupConfig {
     pub install_method: DetailedInstallMethod,
+    pub target_machine_address: String,
+    #[serde(default)]
+    pub expose_public_access: bool,
     pub relational: DetailedRelationalSetupConfig,
     pub rustfs: DetailedRustfsSetupConfig,
     pub search: DetailedSearchSetupConfig,
     pub redis: DetailedRedisSetupConfig,
+}
+
+#[derive(Serialize)]
+pub struct DetailedInstallCommand {
+    pub install_command: String,
+    pub connections: Vec<ConnectionConfig>,
 }
 
 impl SetupOrchestrator {
@@ -343,6 +352,9 @@ impl SetupOrchestrator {
 }
 
 fn validate_detailed_config(config: &DetailedSetupConfig) -> Result<(), String> {
+    if config.target_machine_address.trim().is_empty() {
+        return Err("Target machine address is required".to_string());
+    }
     if !config.relational.enabled && !config.rustfs.enabled && !config.search.enabled && !config.redis.enabled {
         return Err("Select at least one component to configure".to_string());
     }
@@ -369,7 +381,172 @@ fn validate_detailed_config(config: &DetailedSetupConfig) -> Result<(), String> 
     if config.redis.enabled && config.redis.url.trim().is_empty() {
         return Err("Redis URL is required".to_string());
     }
+    if config.expose_public_access {
+        if config.relational.enabled
+            && config.relational.database_type == "mysql"
+            && config.relational.password.is_empty()
+        {
+            return Err("A MySQL password is required when exposing public access".to_string());
+        }
+        if config.rustfs.enabled
+            && (config.rustfs.access_key.is_empty() || config.rustfs.secret_key.is_empty())
+        {
+            return Err("RustFS access and secret keys are required when exposing public access".to_string());
+        }
+        if config.search.enabled {
+            if config.search.search_type == "elasticsearch" && config.search.password.as_deref().unwrap_or_default().is_empty() {
+                return Err("An Elasticsearch password is required when exposing public access".to_string());
+            }
+            if config.search.search_type == "weaviate" && config.search.api_key.as_deref().unwrap_or_default().is_empty() {
+                return Err("A Weaviate API key is required when exposing public access".to_string());
+            }
+        }
+        if config.redis.enabled && config.redis.password.as_deref().unwrap_or_default().is_empty() {
+            return Err("A Redis password is required when exposing public access".to_string());
+        }
+    }
     Ok(())
+}
+
+pub fn generate_detailed_install_command(config: &DetailedSetupConfig) -> Result<DetailedInstallCommand, String> {
+    validate_detailed_config(config)?;
+
+    let compose = detailed_compose(config);
+    let install_command = match &config.install_method {
+        DetailedInstallMethod::Docker => docker_install_command(&compose),
+        DetailedInstallMethod::Binary => binary_install_command(config, &compose),
+    };
+
+    Ok(DetailedInstallCommand {
+        install_command,
+        connections: detailed_connection_configs(config),
+    })
+}
+
+fn docker_install_command(compose: &str) -> String {
+    let compose_base64 = base64_encode(compose.as_bytes());
+    format!(
+        "# Run on the target Linux machine\nmkdir -p ~/zihuan-next-install && cd ~/zihuan-next-install\nprintf '%s' '{compose_base64}' | base64 -d > docker-compose.yaml\ndocker compose -f docker-compose.yaml up -d"
+    )
+}
+
+fn binary_install_command(config: &DetailedSetupConfig, compose: &str) -> String {
+    let compose_base64 = base64_encode(compose.as_bytes());
+    let services = detailed_install_services(config).join(" ");
+    format!(
+        "# Run on the target Linux x86_64 machine\nsudo apt-get update\nsudo apt-get install -y build-essential pkg-config libssl-dev git nodejs npm docker.io docker-compose-plugin\ngit clone --recurse-submodules https://github.com/FredYakumo/zihuan-next.git ~/zihuan-next\ncd ~/zihuan-next\ncorepack enable && corepack prepare pnpm@10.22.0 --activate\ncd webui && pnpm install --frozen-lockfile && pnpm run build\ncd .. && cargo build --release\nmkdir -p ~/zihuan-next-install && cd ~/zihuan-next-install\nprintf '%s' '{compose_base64}' | base64 -d > docker-compose.yaml\ndocker compose -f docker-compose.yaml up -d {services}\n# Start Zihuan Next after importing the generated connections JSON:\n~/zihuan-next/target/release/zihuan_next --host 0.0.0.0 --port 9951"
+    )
+}
+
+fn base64_encode(bytes: &[u8]) -> String {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut output = String::with_capacity((bytes.len() + 2) / 3 * 4);
+    for chunk in bytes.chunks(3) {
+        let first = chunk[0];
+        let second = *chunk.get(1).unwrap_or(&0);
+        let third = *chunk.get(2).unwrap_or(&0);
+        output.push(TABLE[(first >> 2) as usize] as char);
+        output.push(TABLE[((first & 0b0000_0011) << 4 | second >> 4) as usize] as char);
+        output.push(if chunk.len() > 1 { TABLE[((second & 0b0000_1111) << 2 | third >> 6) as usize] as char } else { '=' });
+        output.push(if chunk.len() > 2 { TABLE[(third & 0b0011_1111) as usize] as char } else { '=' });
+    }
+    output
+}
+
+fn detailed_connection_host(config: &DetailedSetupConfig) -> &str {
+    if config.expose_public_access {
+        config.target_machine_address.trim()
+    } else {
+        "127.0.0.1"
+    }
+}
+
+fn detailed_connection_configs(config: &DetailedSetupConfig) -> Vec<ConnectionConfig> {
+    let host = detailed_connection_host(config);
+    let mut connections = Vec::new();
+
+    if config.relational.enabled {
+        let connection = if config.relational.database_type == "sqlite" {
+            config_factory::build_connection(
+                "setup-detailed-sqlite",
+                "SQLite",
+                ConnectionKind::Sqlite(SqliteConnection { path: config.relational.sqlite_path.clone() }),
+            )
+        } else {
+            let url = format!(
+                "mysql://{}:{}@{}:{}/{}",
+                config.relational.username,
+                config.relational.password,
+                host,
+                config.relational.deployment.port,
+                config.relational.database,
+            );
+            config_factory::build_connection(
+                "setup-detailed-mysql",
+                "MySQL",
+                ConnectionKind::Mysql(MysqlConnection {
+                    url,
+                    max_connections: config.relational.max_connections,
+                    acquire_timeout_secs: config.relational.acquire_timeout_secs,
+                }),
+            )
+        };
+        connections.push(connection);
+    }
+    if config.rustfs.enabled {
+        connections.push(config_factory::build_connection(
+            "setup-detailed-rustfs",
+            "RustFS",
+            ConnectionKind::Rustfs(RustfsConnection {
+                endpoint: format!("http://{}:{}", host, config.rustfs.deployment.port),
+                bucket: config.rustfs.bucket.clone(),
+                region: config.rustfs.region.clone(),
+                access_key: config.rustfs.access_key.clone(),
+                secret_key: config.rustfs.secret_key.clone(),
+                public_base_url: config.rustfs.public_base_url.clone(),
+                path_style: config.rustfs.path_style,
+            }),
+        ));
+    }
+    if config.redis.enabled {
+        connections.push(config_factory::build_connection(
+            "setup-detailed-redis",
+            "Redis",
+            ConnectionKind::Redis(RedisConnection {
+                url: format!("redis://{}:{}", host, config.redis.deployment.port),
+                username: config.redis.username.clone(),
+                password: config.redis.password.clone(),
+            }),
+        ));
+    }
+    if config.search.enabled {
+        for (suffix, schema) in [("memory", WeaviateCollectionSchema::AgentMemory), ("image", WeaviateCollectionSchema::ImageSemantic)] {
+            let id = format!("setup-detailed-{}-{suffix}", config.search.search_type);
+            let name = format!("{} {suffix}", config.search.search_type);
+            let kind = if config.search.search_type == "elasticsearch" {
+                ConnectionKind::Elasticsearch(ElasticsearchConnection {
+                    base_url: format!("http://{}:{}", host, config.search.deployment.port),
+                    index_name: format!("zihuan_{suffix}"),
+                    username: config.search.username.clone(),
+                    password: config.search.password.clone(),
+                    api_key: config.search.api_key.clone(),
+                    collection_schema: schema,
+                    vector_dimensions: config.search.vector_dimensions,
+                })
+            } else {
+                ConnectionKind::Weaviate(WeaviateConnection {
+                    base_url: format!("http://{}:{}", host, config.search.deployment.port),
+                    class_name: if suffix == "memory" { "AgentMemory".to_string() } else { "ImageSemantic".to_string() },
+                    username: config.search.username.clone(),
+                    password: config.search.password.clone(),
+                    api_key: config.search.api_key.clone(),
+                    collection_schema: schema,
+                })
+            };
+            connections.push(config_factory::build_connection(&id, &name, kind));
+        }
+    }
+    connections
 }
 
 fn detailed_install_services(config: &DetailedSetupConfig) -> Vec<&'static str> {
@@ -433,16 +610,31 @@ fn detailed_compose(config: &DetailedSetupConfig) -> String {
     let mut services = String::from("services:\n");
     if config.relational.enabled && config.relational.source == DetailedComponentSource::Install && config.relational.database_type == "mysql" {
         let d = &config.relational.deployment;
-        services.push_str(&format!("  mysql:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:3306\"]\n    volumes: [\"{}:/var/lib/mysql\"]\n    environment:\n      MYSQL_ROOT_PASSWORD: {}\n      MYSQL_DATABASE: {}\n", d.image, d.container_name, d.restart_policy, d.port, d.data_dir, config.relational.password, config.relational.database));
+        services.push_str(&format!("  mysql:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:3306\"]\n    volumes: [\"{}:/var/lib/mysql\"]\n    environment:\n      MYSQL_ROOT_PASSWORD: {}\n      MYSQL_DATABASE: {}\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&d.data_dir), yaml_quote(&config.relational.password), yaml_quote(&config.relational.database)));
     }
-    if config.rustfs.enabled && config.rustfs.source == DetailedComponentSource::Install { let d = &config.rustfs.deployment; services.push_str(&format!("  rustfs:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:9000\"]\n    volumes: [\"{}:/data\"]\n    command: [\"--console-enable\", \"/data\"]\n", d.image, d.container_name, d.restart_policy, d.port, d.data_dir)); }
+    if config.rustfs.enabled && config.rustfs.source == DetailedComponentSource::Install { let d = &config.rustfs.deployment; services.push_str(&format!("  rustfs:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:9000\"]\n    volumes: [\"{}:/data\"]\n    environment:\n      RUSTFS_ACCESS_KEY: {}\n      RUSTFS_SECRET_KEY: {}\n    command: [\"--console-enable\", \"/data\"]\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&d.data_dir), yaml_quote(&config.rustfs.access_key), yaml_quote(&config.rustfs.secret_key))); }
     if config.search.enabled && config.search.source == DetailedComponentSource::Install {
         let d = &config.search.deployment;
-        if config.search.search_type == "elasticsearch" { services.push_str(&format!("  elasticsearch:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:9200\"]\n    volumes: [\"{}:/usr/share/elasticsearch/data\"]\n    environment:\n      discovery.type: single-node\n      xpack.security.enabled: 'true'\n      ELASTIC_PASSWORD: {}\n", d.image, d.container_name, d.restart_policy, d.port, d.data_dir, config.search.password.as_deref().unwrap_or_default())); }
-        else { services.push_str(&format!("  weaviate:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:8080\"]\n    volumes: [\"{}:/var/lib/weaviate\"]\n    environment:\n      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'\n      DEFAULT_VECTORIZER_MODULE: none\n      CLUSTER_HOSTNAME: node1\n", d.image, d.container_name, d.restart_policy, d.port, d.data_dir)); }
+        if config.search.search_type == "elasticsearch" { services.push_str(&format!("  elasticsearch:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:9200\"]\n    volumes: [\"{}:/usr/share/elasticsearch/data\"]\n    environment:\n      discovery.type: single-node\n      xpack.security.enabled: 'true'\n      ELASTIC_PASSWORD: {}\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&d.data_dir), yaml_quote(config.search.password.as_deref().unwrap_or_default()))); }
+        else {
+            let authentication = if config.expose_public_access {
+                format!("      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'false'\n      AUTHENTICATION_APIKEY_ENABLED: 'true'\n      AUTHENTICATION_APIKEY_ALLOWED_KEYS: {}\n", yaml_quote(config.search.api_key.as_deref().unwrap_or_default()))
+            } else {
+                "      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'\n".to_string()
+            };
+            services.push_str(&format!("  weaviate:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:8080\"]\n    volumes: [\"{}:/var/lib/weaviate\"]\n    environment:\n{}      DEFAULT_VECTORIZER_MODULE: none\n      CLUSTER_HOSTNAME: node1\n", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&d.data_dir), authentication));
+        }
     }
-    if config.redis.enabled && config.redis.source == DetailedComponentSource::Install { let d = &config.redis.deployment; services.push_str(&format!("  redis:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:6379\"]\n    volumes: [\"{}:/data\"]\n", d.image, d.container_name, d.restart_policy, d.port, d.data_dir)); }
+    if config.redis.enabled && config.redis.source == DetailedComponentSource::Install {
+        let d = &config.redis.deployment;
+        let command = if config.expose_public_access { format!("    command: [\"redis-server\", \"--requirepass\", {}]\n", yaml_quote(config.redis.password.as_deref().unwrap_or_default())) } else { String::new() };
+        services.push_str(&format!("  redis:\n    image: {}\n    container_name: {}\n    restart: {}\n    ports: [\"{}:6379\"]\n    volumes: [\"{}:/data\"]\n{}", yaml_quote(&d.image), yaml_quote(&d.container_name), yaml_quote(&d.restart_policy), d.port, yaml_quote(&d.data_dir), command));
+    }
     services
+}
+
+fn yaml_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
 }
 
 async fn save_detailed_connections(config: &DetailedSetupConfig) -> Result<(), String> {

--- a/src/setup_orchestrator/mod.rs
+++ b/src/setup_orchestrator/mod.rs
@@ -114,6 +114,8 @@ pub struct DetailedSetupConfig {
     pub target_machine_address: String,
     #[serde(default)]
     pub expose_public_access: bool,
+    #[serde(default)]
+    pub use_target_machine_address: bool,
     pub relational: DetailedRelationalSetupConfig,
     pub rustfs: DetailedRustfsSetupConfig,
     pub search: DetailedSearchSetupConfig,
@@ -352,9 +354,6 @@ impl SetupOrchestrator {
 }
 
 fn validate_detailed_config(config: &DetailedSetupConfig) -> Result<(), String> {
-    if config.target_machine_address.trim().is_empty() {
-        return Err("Target machine address is required".to_string());
-    }
     if !config.relational.enabled && !config.rustfs.enabled && !config.search.enabled && !config.redis.enabled {
         return Err("Select at least one component to configure".to_string());
     }
@@ -453,16 +452,15 @@ fn base64_encode(bytes: &[u8]) -> String {
     output
 }
 
-fn detailed_connection_host(config: &DetailedSetupConfig) -> &str {
-    if config.expose_public_access {
+fn detailed_connection_host<'a>(config: &'a DetailedSetupConfig, default: &'a str) -> &'a str {
+    if config.expose_public_access && config.use_target_machine_address && !config.target_machine_address.trim().is_empty() {
         config.target_machine_address.trim()
     } else {
-        "127.0.0.1"
+        default
     }
 }
 
 fn detailed_connection_configs(config: &DetailedSetupConfig) -> Vec<ConnectionConfig> {
-    let host = detailed_connection_host(config);
     let mut connections = Vec::new();
 
     if config.relational.enabled {
@@ -473,6 +471,7 @@ fn detailed_connection_configs(config: &DetailedSetupConfig) -> Vec<ConnectionCo
                 ConnectionKind::Sqlite(SqliteConnection { path: config.relational.sqlite_path.clone() }),
             )
         } else {
+            let host = detailed_connection_host(config, &config.relational.host);
             let url = format!(
                 "mysql://{}:{}@{}:{}/{}",
                 config.relational.username,
@@ -494,11 +493,16 @@ fn detailed_connection_configs(config: &DetailedSetupConfig) -> Vec<ConnectionCo
         connections.push(connection);
     }
     if config.rustfs.enabled {
+        let endpoint = if config.expose_public_access && config.use_target_machine_address && !config.target_machine_address.trim().is_empty() {
+            format!("http://{}:{}", config.target_machine_address.trim(), config.rustfs.deployment.port)
+        } else {
+            config.rustfs.endpoint.clone()
+        };
         connections.push(config_factory::build_connection(
             "setup-detailed-rustfs",
             "RustFS",
             ConnectionKind::Rustfs(RustfsConnection {
-                endpoint: format!("http://{}:{}", host, config.rustfs.deployment.port),
+                endpoint,
                 bucket: config.rustfs.bucket.clone(),
                 region: config.rustfs.region.clone(),
                 access_key: config.rustfs.access_key.clone(),
@@ -509,23 +513,33 @@ fn detailed_connection_configs(config: &DetailedSetupConfig) -> Vec<ConnectionCo
         ));
     }
     if config.redis.enabled {
+        let url = if config.expose_public_access && config.use_target_machine_address && !config.target_machine_address.trim().is_empty() {
+            format!("redis://{}:{}", config.target_machine_address.trim(), config.redis.deployment.port)
+        } else {
+            config.redis.url.clone()
+        };
         connections.push(config_factory::build_connection(
             "setup-detailed-redis",
             "Redis",
             ConnectionKind::Redis(RedisConnection {
-                url: format!("redis://{}:{}", host, config.redis.deployment.port),
+                url,
                 username: config.redis.username.clone(),
                 password: config.redis.password.clone(),
             }),
         ));
     }
     if config.search.enabled {
+        let base_url = if config.expose_public_access && config.use_target_machine_address && !config.target_machine_address.trim().is_empty() {
+            format!("http://{}:{}", config.target_machine_address.trim(), config.search.deployment.port)
+        } else {
+            config.search.base_url.clone()
+        };
         for (suffix, schema) in [("memory", WeaviateCollectionSchema::AgentMemory), ("image", WeaviateCollectionSchema::ImageSemantic)] {
             let id = format!("setup-detailed-{}-{suffix}", config.search.search_type);
             let name = format!("{} {suffix}", config.search.search_type);
             let kind = if config.search.search_type == "elasticsearch" {
                 ConnectionKind::Elasticsearch(ElasticsearchConnection {
-                    base_url: format!("http://{}:{}", host, config.search.deployment.port),
+                    base_url: base_url.clone(),
                     index_name: format!("zihuan_{suffix}"),
                     username: config.search.username.clone(),
                     password: config.search.password.clone(),
@@ -535,7 +549,7 @@ fn detailed_connection_configs(config: &DetailedSetupConfig) -> Vec<ConnectionCo
                 })
             } else {
                 ConnectionKind::Weaviate(WeaviateConnection {
-                    base_url: format!("http://{}:{}", host, config.search.deployment.port),
+                    base_url: base_url.clone(),
                     class_name: if suffix == "memory" { "AgentMemory".to_string() } else { "ImageSemantic".to_string() },
                     username: config.search.username.clone(),
                     password: config.search.password.clone(),

--- a/storage_handler/src/elasticsearch.rs
+++ b/storage_handler/src/elasticsearch.rs
@@ -17,6 +17,8 @@ use crate::{
 use zihuan_core::ims_bot_adapter::models::message::PersistedMedia;
 
 const REQUEST_TIMEOUT_SECS: u64 = 30;
+const INDEX_CHECK_RETRY_ATTEMPTS: usize = 15;
+const INDEX_CHECK_RETRY_DELAY: Duration = Duration::from_secs(1);
 const MAX_QUERY_CANDIDATES: usize = 100;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -115,13 +117,22 @@ impl ElasticsearchRef {
 }
 
 pub fn ensure_elasticsearch_index(reference: &ElasticsearchRef, create_missing: bool) -> Result<bool> {
-    let exists = reference
-        .client
-        .head(format!("{}/{}", reference.base_url, reference.index_name))
-        .send()
-        .map_err(|error| Error::StringError(format!("elasticsearch index check failed: {error}")))?
-        .status()
-        .is_success();
+    let index_url = format!("{}/{}", reference.base_url, reference.index_name);
+    let mut attempt = 0;
+    let exists = loop {
+        match reference.client.head(&index_url).send() {
+            Ok(response) => break response.status().is_success(),
+            Err(error) if attempt + 1 == INDEX_CHECK_RETRY_ATTEMPTS => {
+                return Err(Error::StringError(format!(
+                    "elasticsearch index check failed after {INDEX_CHECK_RETRY_ATTEMPTS} attempts: {error}"
+                )));
+            }
+            Err(_) => {
+                attempt += 1;
+                std::thread::sleep(INDEX_CHECK_RETRY_DELAY);
+            }
+        }
+    };
     if !exists {
         if !create_missing {
             return Err(Error::ValidationError(format!(

--- a/webui/src/admin/composables/useChat.ts
+++ b/webui/src/admin/composables/useChat.ts
@@ -3,12 +3,14 @@ import MarkdownIt from "markdown-it";
 
 import {
   chat,
+  fileIO,
   system,
   type ServiceWithRuntime,
   type ChatHistoryRecord,
   type ChatToolCall,
   type ChatSessionSummary,
   type ChatStreamEvent,
+  type ChatMessagePart,
   type LlmConfig,
 } from "../../api/client";
 import {
@@ -50,6 +52,17 @@ type ChatMessage = {
   agentAvatarUrl?: string;
   agentName?: string;
   liveToolCalls?: LiveToolCall[];
+  imageAttachments?: ChatImageAttachment[];
+};
+type ChatImageAttachment = {
+  id: string;
+  url: string;
+  key: string;
+  name: string;
+  mimeType: string;
+  uploading?: boolean;
+  error?: string;
+  localPreviewUrl?: string;
 };
 type ToolDetail = {
   messageId: string;
@@ -164,6 +177,8 @@ const sessions = ref<ChatSessionSummary[]>([]);
 const activeSessionId = ref("");
 const selectedServiceId = ref("");
 const draftMessage = ref("");
+const draftImageAttachments = ref<ChatImageAttachment[]>([]);
+const imagePreviewAttachment = ref<ChatImageAttachment | null>(null);
 const workspacePath = ref("");
 const pickingDirectory = ref(false);
 const sending = ref(false);
@@ -268,7 +283,8 @@ const canSend = computed(() =>
   !!selectedService.value &&
   isChatEligible.value &&
   selectedService.value.runtime.status === "running" &&
-  draftMessage.value.trim().length > 0,
+  (draftMessage.value.trim().length > 0 || draftImageAttachments.value.length > 0) &&
+  draftImageAttachments.value.every((attachment) => !attachment.uploading && !attachment.error),
 );
 const selectedAgentAvatarUrl = computed(() => agentAvatarUrl(selectedService.value));
 const selectedAgentAvatarFallback = computed(() => {
@@ -370,12 +386,64 @@ function readableAgentType(type: string): string {
   return "QQ Chat Agent Service";
 }
 
+function imageAttachmentToPart(attachment: ChatImageAttachment): ChatMessagePart {
+  return {
+    type: "image",
+    media: {
+      media_id: attachment.key,
+      source: "upload",
+      original_source: attachment.url,
+      rustfs_path: "",
+      name: attachment.name,
+      mime_type: attachment.mimeType,
+    },
+  };
+}
+
+function imageAttachmentsFromParts(parts: ChatMessagePart[] | undefined): ChatImageAttachment[] {
+  return (parts ?? []).flatMap((part, index) => {
+    if (part.type !== "image" || !part.media) {
+      return [];
+    }
+    const url = part.media.rustfs_path || part.media.original_source;
+    if (!url) {
+      return [];
+    }
+    return [{
+      id: part.media.media_id || `history-image-${index}-${url}`,
+      url,
+      key: part.media.media_id,
+      name: part.media.name || "图片",
+      mimeType: part.media.mime_type || "image/*",
+    }];
+  });
+}
+
+function messageParts(content: string, attachments: ChatImageAttachment[] | undefined): ChatMessagePart[] | undefined {
+  if (!attachments?.length) {
+    return undefined;
+  }
+  const parts: ChatMessagePart[] = [];
+  if (content) {
+    parts.push({ type: "text", text: content });
+  }
+  parts.push(...attachments.map(imageAttachmentToPart));
+  return parts;
+}
+
 function toApiMessages() {
   return messages.value
-    .filter((item) => item.content.trim().length > 0 || item.toolCalls.length > 0 || !!item.toolCallId)
+    .filter(
+      (item) =>
+        item.content.trim().length > 0 ||
+        item.imageAttachments?.length ||
+        item.toolCalls.length > 0 ||
+        !!item.toolCallId,
+    )
     .map((item) => ({
       role: item.role,
       content: item.content,
+      parts: messageParts(item.content, item.imageAttachments),
       tool_calls: item.toolCalls.length > 0 ? item.toolCalls : undefined,
       tool_call_id: item.toolCallId ?? undefined,
     }));
@@ -388,6 +456,7 @@ function applyHistory(records: ChatHistoryRecord[]) {
       id: item.message_id,
       role: item.role as ChatRole,
       content: item.content,
+      imageAttachments: imageAttachmentsFromParts(item.parts),
       thinkingContent: item.reasoning_content ?? undefined,
       thinkingExpanded: !autoCollapseThinking.value && !!item.reasoning_content,
       timestamp: item.timestamp,
@@ -541,6 +610,96 @@ function handleTextareaKeydown(event: KeyboardEvent) {
   }
   event.preventDefault();
   sendMessage();
+}
+
+function handleTextareaPaste(event: ClipboardEvent) {
+  const files = Array.from(event.clipboardData?.items ?? [])
+    .filter((item) => item.kind === "file" && item.type.startsWith("image/"))
+    .map((item) => item.getAsFile())
+    .filter((file): file is File => file != null);
+  if (files.length === 0) {
+    return;
+  }
+  event.preventDefault();
+  addImageFiles(files);
+}
+
+function handleImageFileSelection(event: Event) {
+  const input = event.target as HTMLInputElement;
+  if (input.files) {
+    addImageFiles(Array.from(input.files));
+  }
+  input.value = "";
+}
+
+function addImageFiles(files: File[]) {
+  for (const file of files) {
+    if (!file.type.startsWith("image/")) {
+      continue;
+    }
+    const attachment: ChatImageAttachment = {
+      id: crypto.randomUUID(),
+      url: URL.createObjectURL(file),
+      key: "",
+      name: file.name || "图片",
+      mimeType: file.type,
+      uploading: true,
+    };
+    attachment.localPreviewUrl = attachment.url;
+    draftImageAttachments.value.push(attachment);
+    void fileIO.uploadImage(file)
+      .then((uploaded) => {
+        const current = draftImageAttachments.value.find((item) => item.id === attachment.id);
+        if (!current) {
+          return;
+        }
+        if (current.localPreviewUrl) {
+          URL.revokeObjectURL(current.localPreviewUrl);
+        }
+        current.url = uploaded.url;
+        current.key = uploaded.key;
+        current.name = uploaded.name;
+        current.uploading = false;
+        current.localPreviewUrl = undefined;
+      })
+      .catch((error: Error) => {
+        const current = draftImageAttachments.value.find((item) => item.id === attachment.id);
+        if (current) {
+          current.uploading = false;
+          current.error = `上传失败: ${error.message}`;
+        }
+      });
+  }
+}
+
+function removeDraftImageAttachment(id: string) {
+  const index = draftImageAttachments.value.findIndex((attachment) => attachment.id === id);
+  if (index < 0) {
+    return;
+  }
+  const [attachment] = draftImageAttachments.value.splice(index, 1);
+  if (attachment.localPreviewUrl) {
+    URL.revokeObjectURL(attachment.localPreviewUrl);
+  }
+}
+
+function openImagePreview(attachment: ChatImageAttachment) {
+  imagePreviewAttachment.value = attachment;
+}
+
+function closeImagePreview() {
+  imagePreviewAttachment.value = null;
+}
+
+function handleImagePreviewKeydown(event: KeyboardEvent) {
+  if (event.key === "Escape") {
+    closeImagePreview();
+  }
+}
+
+function handleDocumentKeydown(event: KeyboardEvent) {
+  handleToolPreviewKeydown(event);
+  handleImagePreviewKeydown(event);
 }
 
 function toggleAutoCollapseThinking() {
@@ -860,7 +1019,7 @@ async function sendMessageWithText(rawInput: string, fromAskUser: boolean) {
   }
 
   const userText = rawInput.trim();
-  if (!userText) {
+  if (!userText && (!fromAskUser && draftImageAttachments.value.length === 0)) {
     return;
   }
   if (!selectedService.value || selectedService.value.runtime.status !== "running") {
@@ -879,13 +1038,16 @@ async function sendMessageWithText(rawInput: string, fromAskUser: boolean) {
     {
       role: "user",
       content: userText,
+      parts: fromAskUser ? undefined : messageParts(userText, draftImageAttachments.value),
     },
   ];
 
+  const sentAttachments = fromAskUser ? [] : draftImageAttachments.value;
   if (fromAskUser) {
     askUserAnswer.value = "";
   } else {
     draftMessage.value = "";
+    draftImageAttachments.value = [];
   }
   sending.value = true;
 
@@ -904,6 +1066,7 @@ async function sendMessageWithText(rawInput: string, fromAskUser: boolean) {
       toolCalls: [],
       toolCallId: null,
       linkedToolCall: null,
+      imageAttachments: sentAttachments,
     };
     messages.value.push(userMessage);
 
@@ -994,12 +1157,12 @@ onMounted(() => {
     alert(`Chat 加载失败: ${(error as Error).message}`);
   });
   document.addEventListener("click", closePickersOnClickOutside);
-  document.addEventListener("keydown", handleToolPreviewKeydown);
+  document.addEventListener("keydown", handleDocumentKeydown);
 });
 
 onUnmounted(() => {
   document.removeEventListener("click", closePickersOnClickOutside);
-  document.removeEventListener("keydown", handleToolPreviewKeydown);
+  document.removeEventListener("keydown", handleDocumentKeydown);
 });
 
   return {
@@ -1009,6 +1172,8 @@ onUnmounted(() => {
     activeSessionId,
     selectedServiceId,
     draftMessage,
+    draftImageAttachments,
+    imagePreviewAttachment,
     workspacePath,
     pickingDirectory,
     sending,
@@ -1066,6 +1231,12 @@ onUnmounted(() => {
     scrollToBottom,
     clearChatError,
     handleTextareaKeydown,
+    handleTextareaPaste,
+    handleImageFileSelection,
+    removeDraftImageAttachment,
+    openImagePreview,
+    closeImagePreview,
+    handleImagePreviewKeydown,
     toggleAutoCollapseThinking,
     clearPendingAskUser,
     pruneFailedAssistantPlaceholder,

--- a/webui/src/admin/composables/useSetupWizard.ts
+++ b/webui/src/admin/composables/useSetupWizard.ts
@@ -38,6 +38,7 @@ export function useSetupWizard() {
     install_method: "docker",
     target_machine_address: "",
     expose_public_access: false,
+    use_target_machine_address: false,
     relational: {
       enabled: true, source: "install", type: "sqlite",
       deployment: { image: "mysql:8.4", port: 3306, data_dir: "./mysql/data", container_name: "zihuan-mysql", restart_policy: "unless-stopped" },
@@ -103,7 +104,11 @@ export function useSetupWizard() {
     }
   }
 
-  function startDetailedInstallation() {
+  function startDetailedInstallation(option: "local_docker" | "local_binary" | "command_docker" | "command_binary") {
+    if (option.startsWith("local_")) {
+      startInstallation("detailed");
+      return;
+    }
     detailedInstallResult.value = null;
     detailedInstallError.value = null;
     setupApi.generateDetailedInstallCommand(detailedConfig.value)

--- a/webui/src/admin/composables/useSetupWizard.ts
+++ b/webui/src/admin/composables/useSetupWizard.ts
@@ -7,9 +7,10 @@ import {
   type LlmSetupConfig,
   type SetupProgressEvent,
   type DetailedSetupConfig,
+  type DetailedInstallCommandResult,
 } from "../../api/client";
 
-type Step = "mode" | "detailed" | "role" | "environment" | "llm" | "ims_bot_adapter" | "install" | "complete";
+type Step = "mode" | "detailed" | "detailed_result" | "role" | "environment" | "llm" | "ims_bot_adapter" | "install" | "complete";
 type SetupRole = "chat_assistant" | "code_dev_assistant" | "qq_chat_bot" | "ai_butler";
 
 
@@ -35,6 +36,8 @@ export function useSetupWizard() {
   });
   const detailedConfig = ref<DetailedSetupConfig>({
     install_method: "docker",
+    target_machine_address: "",
+    expose_public_access: false,
     relational: {
       enabled: true, source: "install", type: "sqlite",
       deployment: { image: "mysql:8.4", port: 3306, data_dir: "./mysql/data", container_name: "zihuan-mysql", restart_policy: "unless-stopped" },
@@ -56,6 +59,8 @@ export function useSetupWizard() {
       url: "redis://127.0.0.1:6379", username: null, password: null,
     },
   });
+  const detailedInstallResult = ref<DetailedInstallCommandResult | null>(null);
+  const detailedInstallError = ref<string | null>(null);
   const taskId = ref("");
   const installationMode = ref<"role_based" | "detailed">("role_based");
   const installLogs = ref<SetupProgressEvent[]>([]);
@@ -99,7 +104,16 @@ export function useSetupWizard() {
   }
 
   function startDetailedInstallation() {
-    startInstallation("detailed");
+    detailedInstallResult.value = null;
+    detailedInstallError.value = null;
+    setupApi.generateDetailedInstallCommand(detailedConfig.value)
+      .then((result) => {
+        detailedInstallResult.value = result;
+        step.value = "detailed_result";
+      })
+      .catch((error: unknown) => {
+        detailedInstallError.value = error instanceof Error ? error.message : String(error);
+      });
   }
 
   function onRoleSelect(role: SetupRole) {
@@ -174,6 +188,8 @@ export function useSetupWizard() {
     llmConfig,
     imsBotAdapterConfig,
     detailedConfig,
+    detailedInstallResult,
+    detailedInstallError,
     taskId,
     installLogs,
     installError,

--- a/webui/src/admin/composables/useSetupWizard.ts
+++ b/webui/src/admin/composables/useSetupWizard.ts
@@ -41,22 +41,22 @@ export function useSetupWizard() {
     use_target_machine_address: false,
     relational: {
       enabled: true, source: "install", type: "sqlite",
-      deployment: { image: "mysql:8.4", port: 3306, data_dir: "./mysql/data", container_name: "zihuan-mysql", restart_policy: "unless-stopped" },
+      deployment: { image: "mysql:8.4", port: 3306, data_dir: "./data/zihuan-mysql", container_name: "zihuan-mysql", restart_policy: "unless-stopped" },
       host: "127.0.0.1", username: "root", password: "", database: "zihuan", sqlite_path: "zihuan_data.db", max_connections: 32, acquire_timeout_secs: 30,
     },
     rustfs: {
       enabled: true, source: "install",
-      deployment: { image: "rustfs/rustfs:latest", port: 9000, data_dir: "./rustfs/data", container_name: "zihuan-rustfs", restart_policy: "unless-stopped" },
+      deployment: { image: "rustfs/rustfs:latest", port: 9000, data_dir: "./data/zihuan-rustfs", container_name: "zihuan-rustfs", restart_policy: "unless-stopped" },
       endpoint: "http://127.0.0.1:9000", bucket: "zihuan", region: "us-east-1", access_key: "", secret_key: "", public_base_url: null, path_style: true,
     },
     search: {
       enabled: true, source: "install", type: "weaviate",
-      deployment: { image: "cr.weaviate.io/semitechnologies/weaviate:1.30.5", port: 8080, data_dir: "./weaviate/data", container_name: "zihuan-weaviate", restart_policy: "unless-stopped" },
+      deployment: { image: "cr.weaviate.io/semitechnologies/weaviate:1.30.5", port: 8080, data_dir: "./data/zihuan-weaviate", container_name: "zihuan-weaviate", restart_policy: "unless-stopped" },
       base_url: "http://127.0.0.1:8080", username: null, password: null, api_key: null, vector_dimensions: 1024,
     },
     redis: {
       enabled: false, source: "install",
-      deployment: { image: "redis:7", port: 6379, data_dir: "./redis/data", container_name: "zihuan-redis", restart_policy: "unless-stopped" },
+      deployment: { image: "redis:7", port: 6379, data_dir: "./data/zihuan-redis", container_name: "zihuan-redis", restart_policy: "unless-stopped" },
       url: "redis://127.0.0.1:6379", username: null, password: null,
     },
   });

--- a/webui/src/admin/composables/useSetupWizard.ts
+++ b/webui/src/admin/composables/useSetupWizard.ts
@@ -67,6 +67,7 @@ export function useSetupWizard() {
   const installLogs = ref<SetupProgressEvent[]>([]);
   const installError = ref<string | null>(null);
   let cleanupProgress = (() => {}) as () => void;
+  let completionTimer: ReturnType<typeof setTimeout> | null = null;
 
   const showProgressBar = computed(() =>
     ["detailed", "environment", "llm", "ims_bot_adapter", "install", "complete"].includes(step.value),
@@ -152,6 +153,10 @@ export function useSetupWizard() {
     installLogs.value = [];
     installError.value = null;
     cleanupProgress();
+    if (completionTimer !== null) {
+      clearTimeout(completionTimer);
+      completionTimer = null;
+    }
 
     try {
       const res = await setupApi.execute(mode === "detailed" ? {
@@ -172,7 +177,7 @@ export function useSetupWizard() {
         }
         if (event.step === "finished") {
           cleanupProgress();
-          setTimeout(() => {
+          completionTimer = setTimeout(() => {
             step.value = "complete";
           }, 500);
         }
@@ -180,6 +185,20 @@ export function useSetupWizard() {
     } catch (err) {
       installError.value = String(err);
     }
+  }
+
+  function backFromInstallation() {
+    cleanupProgress();
+    cleanupProgress = () => {};
+    if (completionTimer !== null) {
+      clearTimeout(completionTimer);
+      completionTimer = null;
+    }
+    step.value = installationMode.value === "detailed"
+      ? "detailed"
+      : selectedRole.value === "qq_chat_bot"
+        ? "ims_bot_adapter"
+        : "llm";
   }
 
   function finishSetup() {
@@ -206,6 +225,7 @@ export function useSetupWizard() {
     onLlmBack,
     startDetailedInstallation,
     startInstallation,
+    backFromInstallation,
     finishSetup,
   };
 }

--- a/webui/src/admin/setup/DetailedConfigStep.vue
+++ b/webui/src/admin/setup/DetailedConfigStep.vue
@@ -4,21 +4,21 @@
 
     <div class="install-method">
       <span>安装方式</span>
-      <span v-if="environmentLoading" class="install-method-status">正在检测本机安装能力...</span>
-      <template v-else>
-        <label :class="{ unavailable: !dockerSupported }" :title="dockerUnsupportedReason">
-          <input v-model="selectedInstallMethod" type="radio" value="docker" :disabled="!dockerSupported" />
-          Docker <small v-if="!dockerSupported">（本机不支持）</small>
-        </label>
-        <label :class="{ unavailable: !environment.binary_install_available }" :title="environment.binary_install_reason ?? ''">
-          <input v-model="selectedInstallMethod" type="radio" value="binary" :disabled="!environment.binary_install_available" />
-          二进制 <small v-if="!environment.binary_install_available">（本机不支持）</small>
-        </label>
-        <span v-if="isWindows" class="windows-environment">
-          WSL：{{ environment.wsl_available ? "可用" : "不可用" }}；
-          WSL Docker：{{ environment.wsl_docker_available ? "可用" : "不可用" }}
-        </span>
-      </template>
+      <label><input v-model="selectedInstallMethod" type="radio" value="docker" /> 安装命令（Docker）</label>
+      <label><input v-model="selectedInstallMethod" type="radio" value="binary" /> 安装命令（二进制）</label>
+    </div>
+
+    <div class="form-grid global-config">
+      <Field label="目标机器地址">
+        <input v-model="model.target_machine_address" placeholder="例如 203.0.113.10 或 server.example.com" />
+      </Field>
+      <label class="public-access-toggle">
+        <input v-model="model.expose_public_access" type="checkbox" />
+        <span>暴露公网访问</span>
+      </label>
+      <p v-if="model.expose_public_access" class="public-access-hint">
+        公网模式会使用目标机器地址生成连接地址，并要求启用服务配置认证凭据。
+      </p>
     </div>
 
     <template v-if="selectedInstallMethod">
@@ -52,7 +52,8 @@
       </section>
       </div>
 
-      <div class="step-actions"><button class="btn ghost" @click="$emit('back')"><ArrowLeftIcon /> 返回</button><button class="btn primary" @click="$emit('next')">开始配置 <ArrowRightIcon /></button></div>
+      <p v-if="error" class="config-error">{{ error }}</p>
+      <div class="step-actions"><button class="btn ghost" @click="$emit('back')"><ArrowLeftIcon /> 返回</button><button class="btn primary" @click="$emit('next')">配置 <ArrowRightIcon /></button></div>
     </template>
 
     <div v-if="!selectedInstallMethod" class="step-actions step-actions--selection">
@@ -62,11 +63,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from "vue";
+import { ref, watch } from "vue";
 import { ArrowLeftIcon, ArrowRightIcon } from "tdesign-icons-vue-next";
 
 import type { DetailedSetupConfig, DetailedSetupInstallMethod } from "../../api/client";
-import { setup as setupApi, type EnvironmentInfo } from "../../api/client";
 import ComponentHeader from "./SetupComponentHeader.vue";
 import CredentialInput from "./SetupCredentialInput.vue";
 import DeploymentFields from "./SetupDeploymentFields.vue";
@@ -74,37 +74,10 @@ import Field from "./SetupField.vue";
 import SourceChoice from "./SetupSourceChoice.vue";
 
 const model = defineModel<DetailedSetupConfig>({ required: true });
+defineProps<{ error: string | null }>();
 defineEmits<{ (event: "next"): void; (event: "back"): void }>();
 
-const environmentLoading = ref(true);
-const selectedInstallMethod = ref<DetailedSetupInstallMethod | null>(null);
-const environment = ref<EnvironmentInfo>({
-  os: "",
-  os_detail: "",
-  docker_available: false,
-  docker_compose_available: false,
-  binary_install_available: false,
-  binary_install_reason: null,
-  wsl_available: null,
-  wsl_docker_available: null,
-  cuda_version: null,
-  compiler_version: null,
-  proxy: null,
-  services: [],
-});
-const dockerSupported = computed(() => environment.value.docker_compose_available);
-const dockerUnsupportedReason = computed(() => "Docker Compose 不可用，请安装并启动 Docker Desktop 或 Docker Compose");
-const isWindows = computed(() => environment.value.os.toLowerCase() === "windows");
-
-onMounted(async () => {
-  try {
-    environment.value = await setupApi.getEnvironment();
-  } catch (error) {
-    console.error("Failed to detect setup environment", error);
-  } finally {
-    environmentLoading.value = false;
-  }
-});
+const selectedInstallMethod = ref<DetailedSetupInstallMethod>(model.value.install_method);
 
 watch(selectedInstallMethod, (installMethod) => {
   if (installMethod) {

--- a/webui/src/admin/setup/DetailedConfigStep.vue
+++ b/webui/src/admin/setup/DetailedConfigStep.vue
@@ -12,10 +12,10 @@
         </label>
         <label :class="{ unavailable: !environment.binary_install_available }" :title="environment.binary_install_reason ?? ''">
           <input v-model="selectedInstallOption" type="radio" value="local_binary" :disabled="!environment.binary_install_available" />
-          二进制 <small v-if="!environment.binary_install_available">（本机不支持）</small>
+          native程序 <small v-if="!environment.binary_install_available">（本机不支持）</small>
         </label>
         <label><input v-model="selectedInstallOption" type="radio" value="command_docker" /> 安装命令（Docker）</label>
-        <label><input v-model="selectedInstallOption" type="radio" value="command_binary" /> 安装命令（二进制）</label>
+        <label><input v-model="selectedInstallOption" type="radio" value="command_binary" /> 安装命令（native程序）</label>
       </template>
     </div>
 
@@ -114,6 +114,7 @@ const isLocalInstall = computed(() => selectedInstallOption.value.startsWith("lo
 onMounted(async () => {
   try {
     environment.value = await setupApi.getEnvironment();
+    selectedInstallOption.value = getPreferredInstallOption();
   } catch (error) {
     console.error("Failed to detect setup environment", error);
   } finally {
@@ -125,6 +126,16 @@ watch(selectedInstallOption, (option) => {
   const installMethod: DetailedSetupInstallMethod = option.endsWith("docker") ? "docker" : "binary";
   model.value.install_method = installMethod;
 });
+
+function getPreferredInstallOption(): DetailedInstallOption {
+  if (dockerSupported.value) {
+    return "local_docker";
+  }
+  if (environment.value.binary_install_available) {
+    return "local_binary";
+  }
+  return "command_docker";
+}
 
 function setSearchType(type: "weaviate" | "elasticsearch") {
   model.value.search.type = type;

--- a/webui/src/admin/setup/DetailedConfigStep.vue
+++ b/webui/src/admin/setup/DetailedConfigStep.vue
@@ -129,11 +129,11 @@ watch(selectedInstallOption, (option) => {
 function setSearchType(type: "weaviate" | "elasticsearch") {
   model.value.search.type = type;
   if (type === "elasticsearch") {
-    model.value.search.deployment = { ...model.value.search.deployment, image: "docker.elastic.co/elasticsearch/elasticsearch:8.17.0", port: 9200, container_name: "zihuan-elasticsearch" };
+    model.value.search.deployment = { ...model.value.search.deployment, image: "docker.elastic.co/elasticsearch/elasticsearch:8.17.0", port: 9200, data_dir: "./data/zihuan-elasticsearch", container_name: "zihuan-elasticsearch" };
     model.value.search.base_url = "http://127.0.0.1:9200";
     model.value.search.username = "elastic";
   } else {
-    model.value.search.deployment = { ...model.value.search.deployment, image: "cr.weaviate.io/semitechnologies/weaviate:1.30.5", port: 8080, container_name: "zihuan-weaviate" };
+    model.value.search.deployment = { ...model.value.search.deployment, image: "cr.weaviate.io/semitechnologies/weaviate:1.30.5", port: 8080, data_dir: "./data/zihuan-weaviate", container_name: "zihuan-weaviate" };
     model.value.search.base_url = "http://127.0.0.1:8080";
   }
 }

--- a/webui/src/admin/setup/DetailedConfigStep.vue
+++ b/webui/src/admin/setup/DetailedConfigStep.vue
@@ -4,24 +4,42 @@
 
     <div class="install-method">
       <span>安装方式</span>
-      <label><input v-model="selectedInstallMethod" type="radio" value="docker" /> 安装命令（Docker）</label>
-      <label><input v-model="selectedInstallMethod" type="radio" value="binary" /> 安装命令（二进制）</label>
+      <span v-if="environmentLoading" class="install-method-status">正在检测本机安装能力...</span>
+      <template v-else>
+        <label :class="{ unavailable: !dockerSupported }" :title="dockerUnsupportedReason">
+          <input v-model="selectedInstallOption" type="radio" value="local_docker" :disabled="!dockerSupported" />
+          Docker <small v-if="!dockerSupported">（本机不支持）</small>
+        </label>
+        <label :class="{ unavailable: !environment.binary_install_available }" :title="environment.binary_install_reason ?? ''">
+          <input v-model="selectedInstallOption" type="radio" value="local_binary" :disabled="!environment.binary_install_available" />
+          二进制 <small v-if="!environment.binary_install_available">（本机不支持）</small>
+        </label>
+        <label><input v-model="selectedInstallOption" type="radio" value="command_docker" /> 安装命令（Docker）</label>
+        <label><input v-model="selectedInstallOption" type="radio" value="command_binary" /> 安装命令（二进制）</label>
+      </template>
     </div>
 
+    <template v-if="!environmentLoading">
     <div class="form-grid global-config">
-      <Field label="目标机器地址">
-        <input v-model="model.target_machine_address" placeholder="例如 203.0.113.10 或 server.example.com" />
-      </Field>
       <label class="public-access-toggle">
         <input v-model="model.expose_public_access" type="checkbox" />
         <span>暴露公网访问</span>
       </label>
-      <p v-if="model.expose_public_access" class="public-access-hint">
-        公网模式会使用目标机器地址生成连接地址，并要求启用服务配置认证凭据。
-      </p>
+      <template v-if="model.expose_public_access">
+        <label class="public-access-toggle">
+          <input v-model="model.use_target_machine_address" type="checkbox" />
+          <span>使用目标机器地址</span>
+        </label>
+        <Field v-if="model.use_target_machine_address" label="目标机器地址（可选）">
+          <input v-model="model.target_machine_address" placeholder="例如 203.0.113.10 或 server.example.com" />
+        </Field>
+        <p class="public-access-hint">
+          使用目标机器地址会覆盖生成连接配置中的服务地址；启用服务仍需配置认证凭据。
+        </p>
+      </template>
     </div>
 
-    <template v-if="selectedInstallMethod">
+    <template v-if="selectedInstallOption">
       <div class="component-scroll">
       <section class="component-card">
         <ComponentHeader v-model:enabled="model.relational.enabled" title="关系型数据库" />
@@ -53,20 +71,21 @@
       </div>
 
       <p v-if="error" class="config-error">{{ error }}</p>
-      <div class="step-actions"><button class="btn ghost" @click="$emit('back')"><ArrowLeftIcon /> 返回</button><button class="btn primary" @click="$emit('next')">配置 <ArrowRightIcon /></button></div>
+      <div class="step-actions"><button class="btn ghost" @click="$emit('back')"><ArrowLeftIcon /> 返回</button><button class="btn primary" @click="$emit('next', selectedInstallOption)">{{ isLocalInstall ? '开始配置' : '配置' }} <ArrowRightIcon /></button></div>
     </template>
 
-    <div v-if="!selectedInstallMethod" class="step-actions step-actions--selection">
+    <div v-if="!selectedInstallOption" class="step-actions step-actions--selection">
       <button class="btn ghost" @click="$emit('back')"><ArrowLeftIcon /> 返回</button>
     </div>
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import { ArrowLeftIcon, ArrowRightIcon } from "tdesign-icons-vue-next";
 
-import type { DetailedSetupConfig, DetailedSetupInstallMethod } from "../../api/client";
+import { setup as setupApi, type DetailedSetupConfig, type DetailedSetupInstallMethod, type EnvironmentInfo } from "../../api/client";
 import ComponentHeader from "./SetupComponentHeader.vue";
 import CredentialInput from "./SetupCredentialInput.vue";
 import DeploymentFields from "./SetupDeploymentFields.vue";
@@ -75,14 +94,36 @@ import SourceChoice from "./SetupSourceChoice.vue";
 
 const model = defineModel<DetailedSetupConfig>({ required: true });
 defineProps<{ error: string | null }>();
-defineEmits<{ (event: "next"): void; (event: "back"): void }>();
+defineEmits<{ (event: "next", option: DetailedInstallOption): void; (event: "back"): void }>();
 
-const selectedInstallMethod = ref<DetailedSetupInstallMethod>(model.value.install_method);
+type DetailedInstallOption = "local_docker" | "local_binary" | "command_docker" | "command_binary";
 
-watch(selectedInstallMethod, (installMethod) => {
-  if (installMethod) {
-    model.value.install_method = installMethod;
+const environmentLoading = ref(true);
+const environment = ref<EnvironmentInfo>({
+  os: "", os_detail: "", docker_available: false, docker_compose_available: false,
+  binary_install_available: false, binary_install_reason: null, wsl_available: null, wsl_docker_available: null,
+  cuda_version: null, compiler_version: null, proxy: null, services: [],
+});
+const dockerSupported = computed(() => environment.value.docker_compose_available);
+const dockerUnsupportedReason = computed(() => "Docker Compose 不可用，请安装并启动 Docker Desktop 或 Docker Compose");
+const selectedInstallOption = ref<DetailedInstallOption>(
+  model.value.install_method === "docker" ? "command_docker" : "command_binary",
+);
+const isLocalInstall = computed(() => selectedInstallOption.value.startsWith("local_"));
+
+onMounted(async () => {
+  try {
+    environment.value = await setupApi.getEnvironment();
+  } catch (error) {
+    console.error("Failed to detect setup environment", error);
+  } finally {
+    environmentLoading.value = false;
   }
+});
+
+watch(selectedInstallOption, (option) => {
+  const installMethod: DetailedSetupInstallMethod = option.endsWith("docker") ? "docker" : "binary";
+  model.value.install_method = installMethod;
 });
 
 function setSearchType(type: "weaviate" | "elasticsearch") {

--- a/webui/src/admin/setup/DetailedInstallCommandResult.vue
+++ b/webui/src/admin/setup/DetailedInstallCommandResult.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="detailed-install-command-result">
+    <div>
+      <h2>安装命令已生成</h2>
+      <p class="subtitle">在目标 Linux 机器上执行安装命令，然后将连接配置导入系统配置的 connections 字段。</p>
+    </div>
+
+    <section class="command-output">
+      <div class="command-output__header">
+        <h3>安装命令</h3>
+        <button class="btn ghost" @click="copyText(result.install_command, 'command')">
+          <CopyIcon /> {{ copied === 'command' ? '已复制' : '复制' }}
+        </button>
+      </div>
+      <textarea readonly :value="result.install_command" aria-label="安装命令" />
+    </section>
+
+    <section class="command-output">
+      <div class="command-output__header">
+        <h3>连接配置 JSON</h3>
+        <button class="btn ghost" @click="copyText(connectionsJson, 'connections')">
+          <CopyIcon /> {{ copied === 'connections' ? '已复制' : '复制' }}
+        </button>
+      </div>
+      <textarea readonly :value="connectionsJson" aria-label="连接配置 JSON" />
+    </section>
+
+    <p v-if="copyError" class="config-error">{{ copyError }}</p>
+    <div class="step-actions">
+      <button class="btn ghost" @click="$emit('back')"><ArrowLeftIcon /> 返回配置</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { ArrowLeftIcon, CopyIcon } from "tdesign-icons-vue-next";
+
+import type { DetailedInstallCommandResult } from "../../api/client";
+
+const props = defineProps<{ result: DetailedInstallCommandResult }>();
+defineEmits<{ (event: "back"): void }>();
+
+const copied = ref<"command" | "connections" | null>(null);
+const copyError = ref<string | null>(null);
+const connectionsJson = computed(() => JSON.stringify(props.result.connections, null, 2));
+
+async function copyText(value: string, target: "command" | "connections") {
+  copyError.value = null;
+  try {
+    await navigator.clipboard.writeText(value);
+    copied.value = target;
+    window.setTimeout(() => {
+      if (copied.value === target) copied.value = null;
+    }, 1600);
+  } catch (error) {
+    copyError.value = `复制失败：${error instanceof Error ? error.message : String(error)}`;
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.detailed-install-command-result { display: grid; gap: 18px; }
+h2, h3, p { margin: 0; }
+.subtitle { color: var(--admin-muted); }
+.command-output { display: grid; gap: 10px; border: 1px solid var(--admin-border); border-radius: 8px; padding: 16px; }
+.command-output__header, .step-actions { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+textarea { width: 100%; min-height: 220px; box-sizing: border-box; resize: vertical; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; line-height: 1.5; }
+.config-error { color: var(--admin-danger, #c0392b); }
+</style>

--- a/webui/src/admin/setup/InstallationProgress.vue
+++ b/webui/src/admin/setup/InstallationProgress.vue
@@ -26,6 +26,7 @@
     </div>
 
     <div class="actions">
+      <button class="btn ghost" @click="$emit('back')">返回</button>
       <button v-if="error" class="btn primary" @click="$emit('retry')">
         重试
       </button>
@@ -43,7 +44,7 @@ const props = defineProps<{
   error: string | null;
 }>();
 
-defineEmits<{ (e: "done"): void; (e: "retry"): void }>();
+defineEmits<{ (e: "done"): void; (e: "retry"): void; (e: "back"): void }>();
 
 const { logs, error } = useInstallationProgress(props);
 </script>

--- a/webui/src/admin/setup/SetupDeploymentFields.vue
+++ b/webui/src/admin/setup/SetupDeploymentFields.vue
@@ -2,7 +2,7 @@
   <div class="form-grid deployment-fields">
     <SetupField label="镜像 / 版本"><input v-model="deployment.image" /></SetupField>
     <SetupField label="端口"><input v-model.number="deployment.port" type="number" min="1" /></SetupField>
-    <SetupField label="数据目录"><input v-model="deployment.data_dir" /></SetupField>
+    <SetupField label="数据目录"><input v-model="deployment.data_dir" placeholder="./data/容器名" /></SetupField>
     <SetupField label="容器名"><input v-model="deployment.container_name" /></SetupField>
     <SetupField label="重启策略"><select v-model="deployment.restart_policy"><option value="unless-stopped">unless-stopped</option><option value="always">always</option><option value="no">no</option></select></SetupField>
   </div>

--- a/webui/src/admin/styles/admin-app.scss
+++ b/webui/src/admin/styles/admin-app.scss
@@ -1,11 +1,32 @@
 .setup-fullscreen {
   grid-column: 1 / -1;
+  height: 100vh;
   min-height: 100vh;
+  overflow-x: hidden;
+  overflow-y: auto;
   background: var(--admin-bg);
 }
 
+body:has(.setup-fullscreen),
+#app:has(.setup-fullscreen) {
+  height: auto;
+  min-height: 100vh;
+}
+
+body:has(.setup-fullscreen) {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
 .setup-fullscreen:has(.detailed-config-step) {
-  height: 100vh;
   min-height: 0;
-  overflow: hidden;
+  overflow-y: auto;
+}
+
+@media (max-width: 900px) {
+  .setup-fullscreen:has(.detailed-config-step) {
+    height: auto;
+    min-height: 100vh;
+    overflow: visible;
+  }
 }

--- a/webui/src/admin/styles/chat.scss
+++ b/webui/src/admin/styles/chat.scss
@@ -841,6 +841,140 @@
   box-shadow: 0 0 0 3px var(--admin-accent-soft);
 }
 
+.chat-draft-images,
+.chat-message-images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.chat-draft-image {
+  position: relative;
+  width: 92px;
+  min-height: 92px;
+}
+
+.chat-draft-image-preview,
+.chat-message-image {
+  display: block;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--admin-border);
+  border-radius: 10px;
+  background: var(--admin-bg);
+  cursor: zoom-in;
+}
+
+.chat-draft-image-preview {
+  width: 92px;
+  height: 92px;
+}
+
+.chat-message-image {
+  width: 168px;
+  height: 128px;
+}
+
+.chat-draft-image-preview img,
+.chat-message-image img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.chat-draft-image-remove {
+  position: absolute;
+  top: -7px;
+  right: -7px;
+  display: grid;
+  width: 22px;
+  height: 22px;
+  padding: 3px;
+  place-items: center;
+  border: 1px solid var(--admin-bg-elevated);
+  border-radius: 50%;
+  color: #fff;
+  background: var(--admin-danger, #ef4444);
+  cursor: pointer;
+}
+
+.chat-draft-image-status {
+  display: block;
+  margin-top: 4px;
+  color: var(--admin-muted);
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+.chat-draft-image-status--error {
+  color: var(--admin-danger, #ef4444);
+}
+
+.chat-image-upload-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+}
+
+.chat-image-upload-button {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  padding: 0;
+  place-items: center;
+  cursor: pointer;
+}
+
+.chat-image-upload-button :deep(svg),
+.chat-draft-image-remove :deep(svg) {
+  width: 18px;
+  height: 18px;
+}
+
+.chat-image-preview-overlay {
+  position: fixed;
+  z-index: 1200;
+  inset: 0;
+  display: grid;
+  padding: 32px;
+  place-items: center;
+  background: rgb(0 0 0 / 72%);
+}
+
+.chat-image-preview-dialog {
+  position: relative;
+  max-width: min(92vw, 1200px);
+  max-height: 90vh;
+}
+
+.chat-image-preview-dialog img {
+  display: block;
+  max-width: 100%;
+  max-height: 90vh;
+  border-radius: 10px;
+  object-fit: contain;
+}
+
+.chat-image-preview-close {
+  position: absolute;
+  top: -12px;
+  right: -12px;
+  display: grid;
+  width: 32px;
+  height: 32px;
+  padding: 6px;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  color: #fff;
+  background: rgb(0 0 0 / 72%);
+  cursor: pointer;
+}
+
 .chat-input-hint {
   font-size: 12px;
   color: var(--admin-subtle);

--- a/webui/src/admin/styles/detailed-config-step.scss
+++ b/webui/src/admin/styles/detailed-config-step.scss
@@ -6,6 +6,10 @@
 .install-method-status, .windows-environment { color: var(--admin-muted); font-size: 13px; }
 .install-method .unavailable { color: var(--admin-muted); cursor: not-allowed; }
 .install-method .unavailable small { color: inherit; }
+.global-config { align-items: end; }
+.public-access-toggle { display: flex; min-height: 38px; align-items: center; gap: 8px; }
+.public-access-hint { grid-column: 1 / -1; margin: 0; color: var(--admin-muted); font-size: 13px; }
+.config-error { margin: 0; color: var(--admin-danger, #c0392b); }
 .component-scroll {
   flex: 1 1 auto;
   min-height: 0;

--- a/webui/src/admin/styles/setup-wizard.scss
+++ b/webui/src/admin/styles/setup-wizard.scss
@@ -8,9 +8,7 @@
 }
 
 .setup-wizard:has(.detailed-config-step) {
-  height: 100vh;
-  min-height: 0;
-  overflow: hidden;
+  min-height: 100%;
 }
 
 .setup-wizard--detailed {
@@ -102,6 +100,12 @@
 }
 
 @media (max-width: 900px) {
+  .setup-wizard:has(.detailed-config-step) {
+    height: auto;
+    min-height: 100vh;
+    overflow-y: auto;
+  }
+
   .setup-wizard.setup-wizard--detailed {
     display: flex;
     height: auto;

--- a/webui/src/admin/view/Chat.vue
+++ b/webui/src/admin/view/Chat.vue
@@ -407,6 +407,17 @@
                     class="chat-bubble"
                     :class="message.role"
                   >
+                    <div v-if="message.imageAttachments?.length" class="chat-message-images">
+                      <button
+                        v-for="attachment in message.imageAttachments"
+                        :key="attachment.id"
+                        class="chat-message-image"
+                        :title="attachment.name"
+                        @click="openImagePreview(attachment)"
+                      >
+                        <img :src="attachment.url" :alt="attachment.name" />
+                      </button>
+                    </div>
                     <div
                       class="chat-bubble-content markdown-body"
                       v-html="renderMessageContent(message.content, message.streaming)"
@@ -446,16 +457,42 @@
                     </button>
                   </div>
                 </div>
+                <div v-if="draftImageAttachments.length" class="chat-draft-images">
+                  <div v-for="attachment in draftImageAttachments" :key="attachment.id" class="chat-draft-image">
+                    <button class="chat-draft-image-preview" :title="attachment.name" @click="openImagePreview(attachment)">
+                      <img :src="attachment.url" :alt="attachment.name" />
+                    </button>
+                    <span v-if="attachment.uploading" class="chat-draft-image-status">上传中...</span>
+                    <span v-else-if="attachment.error" class="chat-draft-image-status chat-draft-image-status--error">
+                      {{ attachment.error }}
+                    </span>
+                    <button class="chat-draft-image-remove" :aria-label="`删除 ${attachment.name}`" @click="removeDraftImageAttachment(attachment.id)">
+                      <CloseIcon />
+                    </button>
+                  </div>
+                </div>
                 <textarea
                   v-model="draftMessage"
                   placeholder="输入消息"
                   @keydown.enter="handleTextareaKeydown"
+                  @paste="handleTextareaPaste"
                   @input="clearChatError"
                 />
                 <div class="chat-input-hint">使用 shift + enter 换行</div>
                 <div class="chat-input-actions">
                   <button class="btn ghost" @click="startNewSession">新对话</button>
                   <div class="chat-input-right">
+                    <input
+                      id="chat-image-upload"
+                      class="chat-image-upload-input"
+                      type="file"
+                      accept="image/*"
+                      multiple
+                      @change="handleImageFileSelection"
+                    />
+                    <label class="btn ghost chat-image-upload-button" for="chat-image-upload" title="上传图片">
+                      <ImageAddIcon />
+                    </label>
                     <div v-if="isChatEligible" class="chat-model-bar">
                       <div class="model-picker" :class="{ open: openPicker === 'model' }">
                         <button
@@ -648,6 +685,20 @@
 
     <Teleport to="body">
       <div
+        v-if="imagePreviewAttachment"
+        class="chat-image-preview-overlay"
+        @click.self="closeImagePreview"
+        @keydown="handleImagePreviewKeydown"
+      >
+        <div class="chat-image-preview-dialog" role="dialog" aria-modal="true" :aria-label="imagePreviewAttachment.name">
+          <button class="chat-image-preview-close" aria-label="关闭图片预览" @click="closeImagePreview"><CloseIcon /></button>
+          <img :src="imagePreviewAttachment.url" :alt="imagePreviewAttachment.name" />
+        </div>
+      </div>
+    </Teleport>
+
+    <Teleport to="body">
+      <div
         v-if="toolPreviewState"
         class="tool-preview-overlay"
         @click.self="closeToolPreview"
@@ -734,7 +785,7 @@
 </template>
 
 <script setup lang="ts">
-import { CheckIcon, ChevronDownIcon, ChevronRightIcon, CloseIcon, DeleteIcon, EditIcon, ErrorCircleIcon, FileIcon, FolderIcon } from "tdesign-icons-vue-next";
+import { CheckIcon, ChevronDownIcon, ChevronRightIcon, CloseIcon, DeleteIcon, EditIcon, ErrorCircleIcon, FileIcon, FolderIcon, ImageAddIcon } from "tdesign-icons-vue-next";
 
 import { useChat } from "../composables/useChat";
 import ToolCallBadge from "./ToolCallBadge.vue";
@@ -756,6 +807,8 @@ const {
   activeSessionId,
   selectedServiceId,
   draftMessage,
+  draftImageAttachments,
+  imagePreviewAttachment,
   workspacePath,
   pickingDirectory,
   sending,
@@ -812,6 +865,12 @@ const {
   scrollToBottom,
   clearChatError,
   handleTextareaKeydown,
+  handleTextareaPaste,
+  handleImageFileSelection,
+  removeDraftImageAttachment,
+  openImagePreview,
+  closeImagePreview,
+  handleImagePreviewKeydown,
   toggleAutoCollapseThinking,
   clearPendingAskUser,
   pruneFailedAssistantPlaceholder,

--- a/webui/src/admin/view/SetupWizard.vue
+++ b/webui/src/admin/view/SetupWizard.vue
@@ -29,8 +29,15 @@
       <DetailedConfigStep
         v-else-if="step === 'detailed'"
         v-model="detailedConfig"
+        :error="detailedInstallError"
         @next="startDetailedInstallation"
         @back="step = 'mode'"
+      />
+
+      <DetailedInstallCommandResult
+        v-else-if="step === 'detailed_result' && detailedInstallResult"
+        :result="detailedInstallResult"
+        @back="step = 'detailed'"
       />
 
       <EnvironmentCheck
@@ -76,6 +83,7 @@ import brandIconSrc from "../../assets/brand-icon.png";
 import ModeSelection from "../setup/ModeSelection.vue";
 import RoleSelection from "../setup/RoleSelection.vue";
 import DetailedConfigStep from "../setup/DetailedConfigStep.vue";
+import DetailedInstallCommandResult from "../setup/DetailedInstallCommandResult.vue";
 import EnvironmentCheck from "../setup/EnvironmentCheck.vue";
 import LlmConfigStep from "../setup/LlmConfigStep.vue";
 import ImsBotAdapterConfigStep from "../setup/ImsBotAdapterConfigStep.vue";
@@ -90,6 +98,8 @@ const {
   llmConfig,
   imsBotAdapterConfig,
   detailedConfig,
+  detailedInstallResult,
+  detailedInstallError,
   taskId,
   installationMode,
   installLogs,

--- a/webui/src/admin/view/SetupWizard.vue
+++ b/webui/src/admin/view/SetupWizard.vue
@@ -68,6 +68,7 @@
         :error="installError"
         @done="step = 'complete'"
         @retry="startInstallation(installationMode)"
+        @back="backFromInstallation"
       />
 
       <SetupComplete
@@ -112,6 +113,7 @@ const {
   onLlmBack,
   startDetailedInstallation,
   startInstallation,
+  backFromInstallation,
   finishSetup,
 } = useSetupWizard();
 </script>

--- a/webui/src/api/client.ts
+++ b/webui/src/api/client.ts
@@ -462,6 +462,20 @@ export interface ChatToolCall {
   };
 }
 
+export interface ChatMessagePart {
+  type: "text" | "image" | "video";
+  text?: string;
+  media?: {
+    media_id: string;
+    source: "upload" | "qq_chat" | "web_search" | "agent_save";
+    original_source: string;
+    rustfs_path: string;
+    name?: string | null;
+    description?: string | null;
+    mime_type?: string | null;
+  };
+}
+
 export interface ChatHistoryRecord {
   session_id: string;
   agent_id: string;
@@ -470,6 +484,7 @@ export interface ChatHistoryRecord {
   agent_avatar_url: string | null;
   role: string;
   content: string;
+  parts?: ChatMessagePart[];
   reasoning_content?: string | null;
   timestamp: string;
   stream_index?: number | null;
@@ -853,6 +868,7 @@ export const chat = {
       messages: Array<{
         role: string;
         content: string;
+        parts?: ChatMessagePart[];
         tool_calls?: ChatToolCall[];
         tool_call_id?: string | null;
       }>;

--- a/webui/src/api/client.ts
+++ b/webui/src/api/client.ts
@@ -1051,10 +1051,17 @@ export interface DetailedRedisSetupConfig {
 
 export interface DetailedSetupConfig {
   install_method: DetailedSetupInstallMethod;
+  target_machine_address: string;
+  expose_public_access: boolean;
   relational: DetailedRelationalSetupConfig;
   rustfs: DetailedRustfsSetupConfig;
   search: DetailedSearchSetupConfig;
   redis: DetailedRedisSetupConfig;
+}
+
+export interface DetailedInstallCommandResult {
+  install_command: string;
+  connections: ConnectionConfig[];
 }
 
 export const setup = {
@@ -1073,6 +1080,9 @@ export const setup = {
     detailed_config?: DetailedSetupConfig;
   }): Promise<{ accepted: boolean; task_id: string }> {
     return request("POST", "/setup", payload);
+  },
+  generateDetailedInstallCommand(config: DetailedSetupConfig): Promise<DetailedInstallCommandResult> {
+    return request("POST", "/setup/detailed-install-command", { detailed_config: config });
   },
   skip(): Promise<{ ok: boolean }> {
     return request("POST", "/setup/skip");

--- a/webui/src/api/client.ts
+++ b/webui/src/api/client.ts
@@ -1053,6 +1053,7 @@ export interface DetailedSetupConfig {
   install_method: DetailedSetupInstallMethod;
   target_machine_address: string;
   expose_public_access: boolean;
+  use_target_machine_address: boolean;
   relational: DetailedRelationalSetupConfig;
   rustfs: DetailedRustfsSetupConfig;
   search: DetailedSearchSetupConfig;

--- a/zihuan_core/src/llm/model/convert/common.rs
+++ b/zihuan_core/src/llm/model/convert/common.rs
@@ -55,19 +55,25 @@ pub(crate) fn build_responses_content_items(message: &LLMMessage, image_url_as_o
         return Vec::new();
     }
 
+    let text_content_type = if matches!(message.role, MessageRole::Assistant) {
+        "output_text"
+    } else {
+        "input_text"
+    };
+
     message
         .parts
         .iter()
         .map(|part| match part {
             MessagePart::Text { text } => json!({
-                "type": "input_text",
+                "type": text_content_type,
                 "text": text,
             }),
             MessagePart::Image { .. } => {
                 let locator = part.media_locator().unwrap_or_default();
                 if matches!(message.role, MessageRole::Assistant) {
                     json!({
-                        "type": "input_text",
+                        "type": "output_text",
                         "text": format!("[image omitted] {locator}"),
                     })
                 } else if image_url_as_object {
@@ -85,7 +91,7 @@ pub(crate) fn build_responses_content_items(message: &LLMMessage, image_url_as_o
                 }
             }
             MessagePart::Video { .. } => json!({
-                "type": "input_text",
+                "type": text_content_type,
                 "text": format!("[video omitted] {}", part.media_locator().unwrap_or_default()),
             }),
         })

--- a/zihuan_service/src/agent/qq_chat/msg_send.rs
+++ b/zihuan_service/src/agent/qq_chat/msg_send.rs
@@ -143,7 +143,6 @@ pub(crate) fn plan_model_reply(
 
     let mut expanded_segments = Vec::new();
     let mut text_chunk_count = 0usize;
-    let mut image_count = 0usize;
 
     for segment in segments {
         match segment {
@@ -157,7 +156,6 @@ pub(crate) fn plan_model_reply(
                 expanded_segments.push(PlannedSegment::At(AtTargetMessage { target: Some(target) }))
             }
             ReplySegment::Image(image) => {
-                image_count += 1;
                 expanded_segments.push(PlannedSegment::Image(image));
             }
             ReplySegment::NoReply => {}
@@ -166,8 +164,8 @@ pub(crate) fn plan_model_reply(
 
     let reply_message = resolve_reply_message(request.reply_directive.as_ref(), request.trigger_message_id);
 
-    // Use forward-message to avoid flooding the chat with too many individual messages
-    let forced_forward = text_chunk_count >= 3 || image_count > 1;
+    // Use forward messages only for long text because QQ clients may not render images in forward nodes.
+    let forced_forward = text_chunk_count >= 3;
     let mut batches = if forced_forward {
         build_forced_forward_batches(expanded_segments, reply_message, &request.bot_id, &request.bot_name)
     } else {

--- a/zihuan_service/src/agent/tools/natural_language_reply.rs
+++ b/zihuan_service/src/agent/tools/natural_language_reply.rs
@@ -49,7 +49,20 @@ pub(crate) fn review_and_rewrite_reply(
         messages: &review_messages,
         tools: None,
     });
-    let review_text = review_response.content_text_owned().unwrap_or_default();
+    let review_text = review_response
+        .content_text_owned()
+        .filter(|text| !text.trim().is_empty())
+        .ok_or_else(|| {
+            Error::ValidationError(format!(
+                "reply reviewer returned empty text response: model={} api_style={:?} parts={} tool_calls={} reasoning_chars={} usage={:?}",
+                review_llm.get_model_name(),
+                review_llm.api_style(),
+                review_response.parts.len(),
+                review_response.tool_calls.len(),
+                review_response.reasoning_content.as_deref().map(str::len).unwrap_or_default(),
+                review_response.usage,
+            ))
+        })?;
     let review_result = parse_review_result(&review_text)?;
     trace.record_reply_review(
         &request.candidate_message,

--- a/zihuan_service/src/agent/tools/natural_language_reply.rs
+++ b/zihuan_service/src/agent/tools/natural_language_reply.rs
@@ -54,7 +54,7 @@ pub(crate) fn review_and_rewrite_reply(
         .filter(|text| !text.trim().is_empty())
         .ok_or_else(|| {
             Error::ValidationError(format!(
-                "reply reviewer returned empty text response: model={} api_style={:?} parts={} tool_calls={} reasoning_chars={} usage={:?}",
+                "reply reviewer returned empty text response: model={} api_style={:?} parts={} tool_calls={} reasoning_chars={} usage={:?} full_response={review_response:?}",
                 review_llm.get_model_name(),
                 review_llm.api_style(),
                 review_response.parts.len(),


### PR DESCRIPTION
Main updates:

- **Remote install command generation:** The setup wizard can generate Docker/native installation commands for a target Linux machine, together with importable connection configuration JSON. `2f5084b`
- **Public deployment configuration:** Supports public exposure and target machine addresses; generates matching MySQL, RustFS, Redis, Elasticsearch, and Weaviate connection addresses, with required credential validation. `57533da`
- **Standardized deployment data paths:** Service volumes now use `./data/zihuan-*` paths, with Docker Compose volume syntax updates. `5b2579a`, `b719cc8`
- **Setup wizard UX improvements:** Adds a copyable installation-command result page, a back button during installation, and improved environment/deployment configuration flows. `9875e6c`, `2f5084b`, `57533da`
- **Elasticsearch startup reliability:** Adds retry logic for Elasticsearch index checks to handle services that are not ready immediately after startup. `d5e51ab`
- **Logging and model-response diagnostics:** Promotes setup failures to error-level logs and reports empty parsed responses for OpenAI Responses compatibility mode. `56b1424`, `de943f5`, `af902eb`, `034b970`
- **QQ multi-image reply fix:** Corrects multi-image handling in natural-language replies and QQ message sending. `2ba2c93`