### PR TITLE
feat(graph-editor): show node outputs on ports and links

### DIFF
--- a/webui/src/graph/canvas.ts
+++ b/webui/src/graph/canvas.ts
@@ -23,6 +23,7 @@ export class ZihuanCanvas implements CanvasFacade {
   _graphMutationTimer: ReturnType<typeof setTimeout> | null = null;
   _pendingWidgetMutations = new Set<Promise<unknown>>();
   _pendingGraphMutations = new Set<Promise<unknown>>();
+  outputSummariesVisible = true;
   nodeTypes: NodeTypeInfo[] = [];
 
   onNavigationChange?: (labels: string[]) => void;
@@ -148,6 +149,12 @@ export class ZihuanCanvas implements CanvasFacade {
 
   async flushPendingGraphMutations(): Promise<void> {
     await this.graphOps.flushPendingGraphMutations();
+  }
+
+  toggleOutputSummaries(): boolean {
+    this.outputSummariesVisible = !this.outputSummariesVisible;
+    this.lGraph.setDirtyCanvas(true, true);
+    return this.outputSummariesVisible;
   }
 
   canUndo(): boolean {

--- a/webui/src/graph/canvas/graph_ops.ts
+++ b/webui/src/graph/canvas/graph_ops.ts
@@ -2,8 +2,7 @@ import { LiteGraph } from "litegraph.js";
 import { graphs } from "../../api/client";
 import { logger } from "../../api/logger";
 import type { EdgeDefinition, NodeDefinition, NodeGraphDefinition } from "../../api/types";
-import { getBoundaryNodeColors, getDisabledNodeColors, getLiteGraphColors, getPortColor } from "../../ui/theme";
-import { openOverlay } from "../../ui/dialogs/index";
+import { getBoundaryNodeColors, getDisabledNodeColors, getPortColor } from "../../ui/theme";
 import { setupNodeWidgets } from "../widgets";
 import type { BrainToolDefinition, EmbeddedFunctionConfig } from "../../ui/dialogs/types";
 import type { CanvasFacade } from "./types";
@@ -25,11 +24,7 @@ const PROTECTED_BOUNDARY_NODE_IDS = new Set([
   "__graph_outputs__",
 ]);
 
-const OUTPUT_PANEL_HEADER_HEIGHT = 26;
-const OUTPUT_PANEL_MIN_HEIGHT = 142;
-const OUTPUT_PANEL_MAX_HEIGHT = 302;
-const OUTPUT_PANEL_WIDTH = 280;
-const OUTPUT_TEXT_MAX_CHARS = 8_000;
+const EXECUTION_TIME_BAND_HEIGHT = 18;
 
 export class CanvasGraphOps {
   constructor(private readonly canvas: CanvasFacade) {}
@@ -368,23 +363,8 @@ export class CanvasGraphOps {
     node.onDrawForeground = function (this: any, ctx: CanvasRenderingContext2D) {
       drawBindingBadges.call(this, ctx);
       drawHelpButton.call(this, ctx);
-      drawNodeOutputPanel(this, ctx);
     };
     node.onMouseDown = (e: MouseEvent, pos: [number, number]): boolean | undefined => {
-      if (isOutputToggleHit(node, pos)) {
-        node._hideOutput = !node._hideOutput;
-        updateOutputPanelSize(node);
-        this.canvas.lGraph.setDirtyCanvas(true, true);
-        e.preventDefault();
-        e.stopPropagation();
-        return true;
-      }
-      if (isOutputDetailHit(node, pos)) {
-        showOutputDetailDialog(node.title, String(node._outputFullText ?? ""), node._executionTime ?? null);
-        e.preventDefault();
-        e.stopPropagation();
-        return true;
-      }
       const btnX = node.size[0] - 12;
       const btnY = -NODE_TITLE_HEIGHT / 2;
       const dx = pos[0] - btnX;
@@ -417,6 +397,11 @@ export class CanvasGraphOps {
       const title = String(this.title);
       const maxWidth = size[0] - titleHeight - 8;
       ctx.fillText(truncateText(ctx, title, maxWidth), titleHeight, LiteGraph.NODE_TITLE_TEXT_Y - titleHeight);
+      if (this._executionTime) {
+        ctx.font = "10px sans-serif";
+        ctx.fillStyle = "rgba(255,255,255,0.62)";
+        ctx.fillText(`执行时间 ${this._executionTime}`, 8, 12);
+      }
     };
 
     if (nodeDef.position) node.pos = [nodeDef.position.x, nodeDef.position.y];
@@ -483,15 +468,14 @@ export class CanvasGraphOps {
     if (nodeDef.size) {
       node.size = [nodeDef.size.width, nodeDef.size.height];
     }
-    if (nodeDef.output !== null && nodeDef.output !== undefined) {
-      node._outputBaseSize = [node.size[0], node.size[1]];
-      node._outputFullText = formatNodeOutput(nodeDef.output);
-      node._outputText = formatNodeOutputPreview(node._outputFullText);
-      node._executionTime = nodeDef.execution_time ?? null;
-      node._outputNeedsDetail = requiresOutputDetail(nodeDef.output, node._outputFullText);
-      node._hideOutput = false;
-      node.size[0] = Math.max(node.size[0], OUTPUT_PANEL_WIDTH);
-      updateOutputPanelSize(node);
+    node._outputByPort = outputByPort(nodeDef);
+    node._executionTime = nodeDef.execution_time ?? null;
+    if (node._executionTime) {
+      const BaseClass = Object.getPrototypeOf(node).constructor;
+      const TimedClass = class extends BaseClass {};
+      TimedClass.slot_start_y = Number(BaseClass.slot_start_y ?? 0) + EXECUTION_TIME_BAND_HEIGHT;
+      Object.setPrototypeOf(node, TimedClass.prototype);
+      node.size[1] += EXECUTION_TIME_BAND_HEIGHT;
     }
   }
 
@@ -668,184 +652,24 @@ export class CanvasGraphOps {
   }
 }
 
-function formatNodeOutput(output: unknown): string {
-  let value: string;
-  if (typeof output === "string") {
-    value = output;
-  } else {
-    try {
-      value = JSON.stringify(output, null, 2) ?? String(output);
-    } catch {
-      value = String(output);
+function outputByPort(node: NodeDefinition): Record<string, unknown> {
+  if (node.output === null || node.output === undefined) return {};
+  if (node.output_ports.length === 1) {
+    const portName = node.output_ports[0].name;
+    if (
+      typeof node.output === "object"
+      && !Array.isArray(node.output)
+      && Object.prototype.hasOwnProperty.call(node.output, portName)
+    ) {
+      return { [portName]: (node.output as Record<string, unknown>)[portName] };
     }
+    return { [portName]: node.output };
   }
-  return value;
-}
-
-function formatNodeOutputPreview(text: string): string {
-  return text.length > OUTPUT_TEXT_MAX_CHARS
-    ? `${text.slice(0, OUTPUT_TEXT_MAX_CHARS)}\n...（预览已截断，打开详细查看完整内容）`
-    : text;
-}
-
-function outputLines(node: any, ctx: CanvasRenderingContext2D): string[] {
-  const text = String(node._outputText ?? "");
-  const maxWidth = Math.max(80, node.size[0] - 20);
-  const lines: string[] = [];
-  for (const sourceLine of text.split("\n")) {
-    if (!sourceLine) {
-      lines.push("");
-      continue;
-    }
-    let line = "";
-    for (const char of sourceLine) {
-      if (ctx.measureText(line + char).width > maxWidth && line) {
-        lines.push(line);
-        line = char;
-      } else {
-        line += char;
-      }
-    }
-    lines.push(line);
+  if (typeof node.output !== "object" || Array.isArray(node.output)) return {};
+  const record = node.output as Record<string, unknown>;
+  const outputs: Record<string, unknown> = {};
+  for (const port of node.output_ports) {
+    if (Object.prototype.hasOwnProperty.call(record, port.name)) outputs[port.name] = record[port.name];
   }
-  return lines;
-}
-
-function updateOutputPanelSize(node: any): void {
-  const baseHeight = Number(node._outputBaseSize?.[1] ?? node.size[1]);
-  node.size[1] = baseHeight + OUTPUT_PANEL_HEADER_HEIGHT;
-  if (node._hideOutput) return;
-
-  const measuredCanvas = document.createElement("canvas");
-  const ctx = measuredCanvas.getContext("2d");
-  if (!ctx) return;
-  ctx.font = "12px monospace";
-  const lines = outputLines(node, ctx);
-  const maxContentHeight = OUTPUT_PANEL_MAX_HEIGHT - OUTPUT_PANEL_HEADER_HEIGHT;
-  node._outputNeedsDetail = Boolean(node._outputNeedsDetail) || lines.length * 16 + 12 > maxContentHeight;
-  const contentHeight = Math.min(maxContentHeight, Math.max(
-    OUTPUT_PANEL_MIN_HEIGHT - OUTPUT_PANEL_HEADER_HEIGHT,
-    lines.length * 16 + 12,
-  ));
-  node.size[1] = baseHeight + OUTPUT_PANEL_HEADER_HEIGHT + contentHeight;
-}
-
-function isOutputToggleHit(node: any, pos: [number, number]): boolean {
-  if (!node._outputBaseSize) return false;
-  const baseHeight = Number(node._outputBaseSize[1]);
-  return pos[0] >= node.size[0] - 82
-    && pos[0] <= node.size[0] - 8
-    && pos[1] >= baseHeight
-    && pos[1] <= baseHeight + OUTPUT_PANEL_HEADER_HEIGHT;
-}
-
-function isOutputDetailHit(node: any, pos: [number, number]): boolean {
-  if (!node._outputBaseSize || node._hideOutput || !node._outputNeedsDetail) return false;
-  const baseHeight = Number(node._outputBaseSize[1]);
-  return pos[0] >= node.size[0] - 82
-    && pos[0] <= node.size[0] - 8
-    && pos[1] >= node.size[1] - 28
-    && pos[1] <= node.size[1] - 6
-    && pos[1] > baseHeight + OUTPUT_PANEL_HEADER_HEIGHT;
-}
-
-function requiresOutputDetail(output: unknown, text: string): boolean {
-  if (text.length > 1_200) return true;
-  if (output === null || typeof output !== "object") return false;
-  return /"(?:image|video|audio|media|attachment|file|url|base64)"\s*:/i.test(text);
-}
-
-function showOutputDetailDialog(title: string, text: string, executionTime: string | null): void {
-  const { overlay, dialog, close } = openOverlay();
-  dialog.style.width = "min(900px, 88vw)";
-  dialog.style.maxWidth = "900px";
-  const heading = document.createElement("h3");
-  heading.textContent = `${title} - 执行输出`;
-  dialog.appendChild(heading);
-  if (executionTime) {
-    const time = document.createElement("div");
-    time.className = "zh-hint";
-    time.textContent = `执行时间 ${executionTime}`;
-    dialog.appendChild(time);
-  }
-  const content = document.createElement("pre");
-  content.style.cssText = "margin:0;max-height:60vh;overflow:auto;white-space:pre-wrap;word-break:break-word;font:12px/1.5 monospace;";
-  content.textContent = text;
-  dialog.appendChild(content);
-  const buttons = document.createElement("div");
-  buttons.className = "zh-buttons";
-  const closeButton = document.createElement("button");
-  closeButton.className = "primary";
-  closeButton.textContent = "关闭";
-  closeButton.addEventListener("click", close);
-  buttons.appendChild(closeButton);
-  dialog.appendChild(buttons);
-  overlay.addEventListener("click", (event) => {
-    if (event.target === overlay) close();
-  });
-  setTimeout(() => closeButton.focus(), 0);
-}
-
-function drawNodeOutputPanel(node: any, ctx: CanvasRenderingContext2D): void {
-  if (!node._outputBaseSize) return;
-  const colors = getLiteGraphColors();
-  const baseHeight = Number(node._outputBaseSize[1]);
-  const width = Number(node.size[0]);
-  const panelHeight = Number(node.size[1]) - baseHeight;
-  const hidden = !!node._hideOutput;
-
-  ctx.save();
-  ctx.fillStyle = "rgba(90, 111, 132, 0.08)";
-  ctx.fillRect(0, baseHeight, width, panelHeight);
-  ctx.strokeStyle = colors.widgetOutline;
-  ctx.strokeRect(0.5, baseHeight + 0.5, width - 1, panelHeight - 1);
-  ctx.font = "11px sans-serif";
-  ctx.textBaseline = "middle";
-  ctx.fillStyle = colors.widgetSecondary;
-  ctx.fillText(node._executionTime ? `执行时间 ${node._executionTime}` : "执行输出", 9, baseHeight + 13);
-
-  const toggleX = width - 77;
-  const toggleY = baseHeight + 8;
-  ctx.strokeStyle = colors.widgetText;
-  ctx.strokeRect(toggleX, toggleY, 10, 10);
-  if (hidden) {
-    ctx.beginPath();
-    ctx.moveTo(toggleX + 2, toggleY + 5);
-    ctx.lineTo(toggleX + 4, toggleY + 8);
-    ctx.lineTo(toggleX + 9, toggleY + 2);
-    ctx.stroke();
-  }
-  ctx.fillStyle = colors.widgetText;
-  ctx.fillText("隐藏输出", toggleX + 15, baseHeight + 13);
-
-  if (!hidden) {
-    ctx.save();
-    ctx.beginPath();
-    ctx.rect(8, baseHeight + OUTPUT_PANEL_HEADER_HEIGHT + 4, width - 16, panelHeight - OUTPUT_PANEL_HEADER_HEIGHT - 8);
-    ctx.clip();
-    ctx.font = "12px monospace";
-    ctx.textBaseline = "top";
-    ctx.fillStyle = colors.widgetText;
-    const lines = outputLines(node, ctx);
-    const maxLines = Math.floor((panelHeight - OUTPUT_PANEL_HEADER_HEIGHT - (node._outputNeedsDetail ? 34 : 12)) / 16);
-    for (let index = 0; index < Math.min(lines.length, maxLines); index++) {
-      ctx.fillText(lines[index], 10, baseHeight + OUTPUT_PANEL_HEADER_HEIGHT + 8 + index * 16);
-    }
-    if (node._outputNeedsDetail) {
-      const buttonX = width - 78;
-      const buttonY = baseHeight + panelHeight - 25;
-      ctx.fillStyle = colors.widgetButtonBg;
-      ctx.fillRect(buttonX, buttonY, 70, 18);
-      ctx.strokeStyle = colors.widgetOutline;
-      ctx.strokeRect(buttonX + 0.5, buttonY + 0.5, 69, 17);
-      ctx.font = "11px sans-serif";
-      ctx.textBaseline = "middle";
-      ctx.fillStyle = colors.widgetButtonText;
-      ctx.textAlign = "center";
-      ctx.fillText("打开详细", buttonX + 35, buttonY + 9);
-      ctx.textAlign = "left";
-    }
-    ctx.restore();
-  }
-  ctx.restore();
+  return outputs;
 }

--- a/webui/src/graph/canvas/patches.ts
+++ b/webui/src/graph/canvas/patches.ts
@@ -144,6 +144,7 @@ export function installLiteGraphPatches(): void {
   // ±8×5 px so the user must click within ~8 px of the port circle itself.
   const originalProcessMouseDown = (LGraphCanvas.prototype as any).processMouseDown;
   (LGraphCanvas.prototype as any).processMouseDown = function (e: any) {
+    if (this._zhOutputSummaryClick?.(e)) return;
     const node: any = this.graph?.getNodeOnPos?.(e.canvasX, e.canvasY, this.visible_nodes);
     if (!node) return originalProcessMouseDown.call(this, e);
 

--- a/webui/src/graph/canvas/rendering.ts
+++ b/webui/src/graph/canvas/rendering.ts
@@ -2,10 +2,22 @@ import { LiteGraph } from "litegraph.js";
 import type { CanvasFacade } from "./types";
 import { getInlineRowCenterY, getInlineWidgetHeight, getInlineWidgetTopY } from "../inline_layout";
 import { getBoundaryNodeColors, getLiteGraphColors, onThemeChange } from "../../ui/theme";
+import { openOverlay } from "../../ui/dialogs/index";
 import { resolveConcretePortType } from "./type_utils";
 
 export const NODE_TITLE_HEIGHT = 30;
 export const DESC_BAND_HEIGHT = 20;
+
+interface OutputSummaryHitRect {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+  nodeTitle: string;
+  portName: string;
+  output: unknown;
+  executionTime: string | null;
+}
 
 export function bindThemeLifecycle(canvas: CanvasFacade): void {
   applyLiteGraphTheme(canvas);
@@ -205,7 +217,186 @@ export function bindCanvasRendering(canvas: CanvasFacade, onNodesMoved: () => vo
       void targetDef;
     }
     ctx.restore();
+    drawOutputSummaries(canvas, ctx, links, allNodes, scale, occupiedRects);
   };
+
+  const handleOutputSummaryClick = (event: MouseEvent): boolean => {
+    if (!canvas.outputSummariesVisible) return false;
+    const [x, y] = (lCanvas as any).convertEventToCanvasOffset(event) as [number, number];
+    const hitRects = ((lCanvas as any)._zhOutputSummaryHitRects ?? []) as OutputSummaryHitRect[];
+    const hit = hitRects.find((rect) => x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom);
+    if (!hit) return false;
+    showOutputDetailDialog(hit.nodeTitle, hit.portName, hit.output, hit.executionTime);
+    event.preventDefault();
+    event.stopPropagation();
+    return true;
+  };
+  (lCanvas as any)._zhOutputSummaryClick = handleOutputSummaryClick;
+
+  const canvasElement = (lCanvas as any).canvas as HTMLCanvasElement;
+  window.addEventListener("mousedown", (event: MouseEvent) => {
+    if (event.target !== canvasElement || !handleOutputSummaryClick(event)) return;
+    event.stopImmediatePropagation();
+  }, true);
+}
+
+function drawOutputSummaries(
+  canvas: CanvasFacade,
+  ctx: CanvasRenderingContext2D,
+  links: Record<number, any>,
+  allNodes: any[],
+  scale: number,
+  occupiedRects: Array<{ left: number; top: number; right: number; bottom: number }>,
+): void {
+  const lCanvas = canvas.lCanvas as any;
+  const hitRects: OutputSummaryHitRect[] = [];
+  lCanvas._zhOutputSummaryHitRects = hitRects;
+  if (!canvas.outputSummariesVisible) return;
+
+  const linksByOutput = new Map<string, any[]>();
+  for (const link of Object.values(links)) {
+    if (!link || link.origin_id === undefined) continue;
+    const key = `${link.origin_id}:${link.origin_slot}`;
+    const siblings = linksByOutput.get(key) ?? [];
+    siblings.push(link);
+    linksByOutput.set(key, siblings);
+  }
+
+  ctx.save();
+  ctx.font = `${Math.round(11 / scale)}px sans-serif`;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  for (const node of allNodes) {
+    const values = node?._outputByPort as Record<string, unknown> | undefined;
+    if (!values || !node.outputs) continue;
+    for (let slot = 0; slot < node.outputs.length; slot++) {
+      const port = node.outputs[slot];
+      if (!port || !Object.prototype.hasOwnProperty.call(values, port.name)) continue;
+      const value = values[port.name];
+      const outgoing = linksByOutput.get(`${node.id}:${slot}`) ?? [];
+      if (outgoing.length > 0) {
+        const sourcePortPos = new Float32Array(2);
+        node.getConnectionPos(false, slot, sourcePortPos);
+        for (const link of outgoing) {
+          const pos = getLinkLabelPosition(link);
+          if (!pos) continue;
+          drawOutputSummaryPill(
+            ctx,
+            pos[0],
+            pos[1] + 18 / scale,
+            value,
+            node.title,
+            port.name,
+            node._executionTime ?? null,
+            scale,
+            occupiedRects,
+            hitRects,
+            "center",
+            sourcePortPos[0] + 8 / scale,
+          );
+        }
+        continue;
+      }
+
+      const connectionPos = new Float32Array(2);
+      node.getConnectionPos(false, slot, connectionPos);
+      drawOutputSummaryPill(
+        ctx,
+        connectionPos[0] + 10 / scale,
+        connectionPos[1],
+        value,
+        node.title,
+        port.name,
+        node._executionTime ?? null,
+        scale,
+        occupiedRects,
+        hitRects,
+        "left",
+      );
+    }
+  }
+  ctx.restore();
+}
+
+function drawOutputSummaryPill(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  initialY: number,
+  output: unknown,
+  nodeTitle: string,
+  portName: string,
+  executionTime: string | null,
+  scale: number,
+  occupiedRects: Array<{ left: number; top: number; right: number; bottom: number }>,
+  hitRects: OutputSummaryHitRect[],
+  align: "center" | "left" = "center",
+  minimumLeft = Number.NEGATIVE_INFINITY,
+): void {
+  const paddingX = 6 / scale;
+  const paddingY = 4 / scale;
+  const fontSize = Math.round(10 / scale);
+  const text = truncateText(ctx, formatOutputSummary(output), 120 / scale);
+  const width = ctx.measureText(text).width + paddingX * 2;
+  const height = fontSize + paddingY * 2;
+  const left = Math.max(align === "center" ? x - width / 2 : x, minimumLeft);
+  let top = initialY - height / 2;
+  let rect = { left, top, right: left + width, bottom: top + height };
+  for (let attempt = 0; attempt < 6 && occupiedRects.some((other) => rectsOverlap(rect, other)); attempt++) {
+    top += height + 4 / scale;
+    rect = { left, top, right: left + width, bottom: top + height };
+  }
+  occupiedRects.push(rect);
+
+  const colors = getLiteGraphColors();
+  ctx.fillStyle = colors.widgetButtonBg;
+  ctx.strokeStyle = colors.widgetOutline;
+  ctx.beginPath();
+  (ctx as any).roundRect(rect.left, rect.top, width, height, 3 / scale);
+  ctx.fill();
+  ctx.stroke();
+  ctx.fillStyle = colors.widgetButtonText;
+  ctx.fillText(text, rect.left + width / 2, rect.top + height / 2);
+  hitRects.push({ ...rect, nodeTitle, portName, output, executionTime });
+}
+
+function formatOutputSummary(output: unknown): string {
+  if (typeof output === "string") return output.replace(/\s+/g, " ").trim() || "(空字符串)";
+  try {
+    return JSON.stringify(output) ?? String(output);
+  } catch {
+    return String(output);
+  }
+}
+
+function showOutputDetailDialog(title: string, portName: string, output: unknown, executionTime: string | null): void {
+  const { overlay, dialog, close } = openOverlay();
+  dialog.style.width = "min(900px, 88vw)";
+  dialog.style.maxWidth = "900px";
+  const heading = document.createElement("h3");
+  heading.textContent = `${title} - ${portName} 输出`;
+  dialog.appendChild(heading);
+  if (executionTime) {
+    const time = document.createElement("div");
+    time.className = "zh-hint";
+    time.textContent = `执行时间 ${executionTime}`;
+    dialog.appendChild(time);
+  }
+  const content = document.createElement("pre");
+  content.style.cssText = "margin:0;max-height:60vh;overflow:auto;white-space:pre-wrap;word-break:break-word;font:12px/1.5 monospace;";
+  content.textContent = typeof output === "string" ? output : JSON.stringify(output, null, 2) ?? String(output);
+  dialog.appendChild(content);
+  const buttons = document.createElement("div");
+  buttons.className = "zh-buttons";
+  const closeButton = document.createElement("button");
+  closeButton.className = "primary";
+  closeButton.textContent = "关闭";
+  closeButton.addEventListener("click", close);
+  buttons.appendChild(closeButton);
+  dialog.appendChild(buttons);
+  overlay.addEventListener("click", (event) => {
+    if (event.target === overlay) close();
+  });
+  setTimeout(() => closeButton.focus(), 0);
 }
 
 function bindDrawNodeWidgets(canvas: CanvasFacade) {

--- a/webui/src/graph/canvas/types.ts
+++ b/webui/src/graph/canvas/types.ts
@@ -29,6 +29,7 @@ export interface CanvasFacade {
   _graphMutationTimer: ReturnType<typeof setTimeout> | null;
   _pendingWidgetMutations: Set<Promise<unknown>>;
   _pendingGraphMutations: Set<Promise<unknown>>;
+  outputSummariesVisible: boolean;
   nodeTypes: NodeTypeInfo[];
   onNavigationChange?: (labels: string[]) => void;
   onGraphDirty?: () => void;
@@ -62,4 +63,5 @@ export interface CanvasFacade {
     graphX: number,
     graphY: number,
   ): Promise<void>;
+  toggleOutputSummaries(): boolean;
 }

--- a/webui/src/graph_editor_bootstrap.ts
+++ b/webui/src/graph_editor_bootstrap.ts
@@ -25,6 +25,18 @@ import { GraphActions } from "./app/graph_actions";
 import { WorkspaceController } from "./app/workspace_controller";
 import { openTaskManagerDialog } from "./ui/dialogs/index";
 
+const TASK_TRACE_NODE_PREFIX = "qq_chat_";
+// Initial x-coordinate for the task trace graph layout.
+const TASK_TRACE_ORIGIN_X = 60;
+// Initial y-coordinate for the task trace graph layout.
+const TASK_TRACE_ORIGIN_Y = 60;
+// Maximum width of a task trace graph row before wrapping to the next row.
+const TASK_TRACE_MAX_ROW_WIDTH = 1440;
+// Horizontal gap between adjacent task trace nodes in the same row.
+const TASK_TRACE_HORIZONTAL_GAP = 72;
+// Vertical gap between adjacent task trace graph rows.
+const TASK_TRACE_VERTICAL_GAP = 80;
+
 export async function bootstrapGraphEditor() {
   initTheme();
   await loadThemes();
@@ -154,6 +166,7 @@ export async function bootstrapGraphEditor() {
     await graphs.put(tab.id, snapshot);
     await tabs.openTab(tab.id, snapshot.metadata.name ?? `任务节点图 ${taskId.slice(0, 8)}`, false);
     await canvas.loadExternalSession(tab.id);
+    await layoutTaskTraceGraph(canvas);
     // This session is a fresh copy of the immutable task snapshot. Saving it can
     // never overwrite the task record; users can use Save As to make a workflow.
     tabs.setTabDirty(tab.id, false);
@@ -209,6 +222,7 @@ export async function bootstrapGraphEditor() {
     () => { graphActions.addNodeWithDialog().catch(console.error); },
     () => { graphActions.execute().catch(console.error); },
     () => { graphActions.stopTask().catch(console.error); },
+    () => canvas.toggleOutputSummaries(),
   ));
 
   const onNewGraph = () => createNewTab().catch((e: Error) => {
@@ -287,4 +301,62 @@ export async function bootstrapGraphEditor() {
   } catch {
     // Startup restoration failed — user can create one manually.
   }
+}
+
+async function layoutTaskTraceGraph(canvas: ZihuanCanvas): Promise<void> {
+  const graph = canvas.state.graph;
+  const sessionId = canvas.sessionId;
+  if (!graph || !sessionId || graph.nodes.length === 0) return;
+  if (!graph.nodes.every((node) => node.node_type.startsWith(TASK_TRACE_NODE_PREFIX))) return;
+
+  const rows: Array<Array<{ id: string; width: number; height: number }>> = [];
+  let rowWidth = 0;
+  for (const nodeDef of graph.nodes) {
+    const renderedNode = canvas.nodeMap.get(nodeDef.id);
+    const width = Math.max(
+      220,
+      Number(renderedNode?.size?.[0] ?? nodeDef.size?.width ?? 220),
+    );
+    const height = Math.max(
+      120,
+      Number(renderedNode?.size?.[1] ?? nodeDef.size?.height ?? 120),
+    );
+    const nextWidth = rowWidth === 0 ? width : rowWidth + TASK_TRACE_HORIZONTAL_GAP + width;
+    if (rows.length > 0 && rowWidth > 0 && nextWidth > TASK_TRACE_MAX_ROW_WIDTH) {
+      rows.push([]);
+      rowWidth = 0;
+    }
+    if (rows.length === 0) rows.push([]);
+    const row = rows[rows.length - 1];
+    rowWidth = row.length === 0 ? width : rowWidth + TASK_TRACE_HORIZONTAL_GAP + width;
+    row.push({ id: nodeDef.id, width, height });
+  }
+
+  const positions = new Map<string, { x: number; y: number }>();
+  let y = TASK_TRACE_ORIGIN_Y;
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+    const row = rows[rowIndex];
+    const visualOrder = rowIndex % 2 === 0 ? row : [...row].reverse();
+    let x = TASK_TRACE_ORIGIN_X;
+    for (const node of visualOrder) {
+      positions.set(node.id, { x, y });
+      x += node.width + TASK_TRACE_HORIZONTAL_GAP;
+    }
+    y += Math.max(...row.map((node) => node.height)) + TASK_TRACE_VERTICAL_GAP;
+  }
+
+  const positionedGraph = {
+    ...graph,
+    nodes: graph.nodes.map((node) => {
+      const position = positions.get(node.id);
+      return position ? { ...node, position } : node;
+    }),
+  };
+  for (const [nodeId, position] of positions) {
+    const renderedNode = canvas.nodeMap.get(nodeId);
+    if (renderedNode) renderedNode.pos = [position.x, position.y];
+  }
+  canvas.state.graph = positionedGraph;
+  canvas.lGraph.setDirtyCanvas(true, true);
+  await graphs.put(sessionId, positionedGraph);
 }

--- a/webui/src/ui/shell/panel.ts
+++ b/webui/src/ui/shell/panel.ts
@@ -1,4 +1,4 @@
-import { CloseIcon, PlayCircleIcon, StopCircleIcon } from "tdesign-icons-vue-next";
+import { BrowseIcon, BrowseOffIcon, CloseIcon, PlayCircleIcon, StopCircleIcon } from "tdesign-icons-vue-next";
 
 import { appendIcon, setButtonIcon } from "../icon";
 
@@ -16,6 +16,7 @@ export function buildCanvasPanelButtons(
   onAddNode: () => void,
   onExecute: () => void,
   onStopTask: () => void,
+  onToggleOutputSummaries: () => boolean,
 ): {
   updateRunButton: (isRunning: boolean) => void;
   appendLogEntry: (level: string, message: string, timestamp: string) => void;
@@ -40,6 +41,17 @@ export function buildCanvasPanelButtons(
   varBtn.title = "管理图变量";
   varBtn.addEventListener("click", onVariables);
   panel.appendChild(varBtn);
+
+  const outputBtn = document.createElement("button");
+  outputBtn.className = "canvas-output-toggle";
+  outputBtn.title = "隐藏输出摘要";
+  setButtonIcon(outputBtn, BrowseIcon, "隐藏输出摘要");
+  outputBtn.addEventListener("click", () => {
+    const visible = onToggleOutputSummaries();
+    outputBtn.title = visible ? "隐藏输出摘要" : "显示输出摘要";
+    setButtonIcon(outputBtn, visible ? BrowseIcon : BrowseOffIcon, outputBtn.title);
+  });
+  panel.appendChild(outputBtn);
 
   const MAX_BUFFER = 1000;
   const logBuffer: Array<{ level: string; message: string; timestamp: string }> = [];

--- a/zihuan_service/src/agent/qq_chat/logging.rs
+++ b/zihuan_service/src/agent/qq_chat/logging.rs
@@ -18,8 +18,24 @@ use zihuan_graph_engine::graph_io::{
 use zihuan_graph_engine::{DataType, Port};
 
 const LOG_PREFIX: &str = "[QqChatAgentService]";
+// Maximum number of characters retained for a text segment in regular logs.
 const LOG_TEXT_PREVIEW_CHARS: usize = 1_200;
+// Maximum number of characters retained for tool arguments and results in logs.
 const LOG_TOOL_PREVIEW_CHARS: usize = 600;
+// Initial x-coordinate for the task graph layout.
+const TASK_GRAPH_ORIGIN_X: f32 = 60.0;
+// Initial y-coordinate for the task graph layout.
+const TASK_GRAPH_ORIGIN_Y: f32 = 60.0;
+// Maximum width of a task graph row before wrapping to the next row.
+const TASK_GRAPH_MAX_ROW_WIDTH: f32 = 1_440.0;
+// Standard width of a task graph node.
+const TASK_GRAPH_NODE_WIDTH: f32 = 280.0;
+// Base height of a task graph node.
+const TASK_GRAPH_BASE_NODE_HEIGHT: f32 = 120.0;
+// Horizontal gap between adjacent task graph nodes in the same row.
+const TASK_GRAPH_HORIZONTAL_GAP: f32 = 72.0;
+// Vertical gap between adjacent task graph rows.
+const TASK_GRAPH_VERTICAL_GAP: f32 = 80.0;
 
 #[derive(Debug, Clone)]
 struct TracePoint {
@@ -651,8 +667,10 @@ impl QqChatTaskTrace {
 
     pub(crate) fn graph_definition(&self, task_id: &str) -> NodeGraphDefinition {
         let inner = self.inner.lock().unwrap();
+        let mut nodes = inner.graph_nodes.clone();
+        layout_task_graph_nodes(&mut nodes);
         NodeGraphDefinition {
-            nodes: inner.graph_nodes.clone(),
+            nodes,
             edges: inner.graph_edges.clone(),
             metadata: GraphMetadata {
                 name: Some(format!("QQ Chat 回复任务 {task_id}")),
@@ -667,7 +685,6 @@ impl QqChatTaskTrace {
         let mut inner = self.inner.lock().unwrap();
         let id = format!("step_{:03}", inner.graph_nodes.len() + 1);
         let previous = inner.graph_nodes.last().map(|node| node.id.clone());
-        let position_x = inner.graph_nodes.len() as f32 * 260.0;
         inner.graph_nodes.push(NodeDefinition {
             id: id.clone(),
             name: name.to_string(),
@@ -675,11 +692,14 @@ impl QqChatTaskTrace {
             node_type: node_type.to_string(),
             input_ports: vec![Port::new("previous", DataType::Json).optional()],
             output_ports: vec![Port::new("result", DataType::Json)],
-            output: Some(output),
+            output: Some(serde_json::json!({ "result": output })),
             execution_time: Some(Local::now().to_rfc3339()),
             dynamic_input_ports: false,
             dynamic_output_ports: false,
-            position: Some(GraphPosition { x: position_x, y: 180.0 }),
+            position: Some(GraphPosition {
+                x: TASK_GRAPH_ORIGIN_X,
+                y: TASK_GRAPH_ORIGIN_Y,
+            }),
             size: Some(zihuan_graph_engine::graph_io::GraphSize { width: 220.0, height: 120.0 }),
             inline_values: HashMap::new(),
             port_bindings: HashMap::new(),
@@ -703,7 +723,7 @@ impl QqChatTaskTrace {
             return;
         }
         if let Some(node) = self.inner.lock().unwrap().graph_nodes.iter_mut().find(|node| node.id == id) {
-            node.output = Some(output);
+            node.output = Some(serde_json::json!({ "result": output }));
             node.execution_time = Some(Local::now().to_rfc3339());
         }
     }
@@ -711,6 +731,58 @@ impl QqChatTaskTrace {
     fn log_key_event(&self, title: &str, duration_ms: u128, details: impl AsRef<str>) {
         info!("{LOG_PREFIX} {title} [耗时 {duration_ms} ms] {}", details.as_ref());
     }
+}
+
+fn layout_task_graph_nodes(nodes: &mut [NodeDefinition]) {
+    let mut rows: Vec<Vec<usize>> = Vec::new();
+    let mut row_width = 0.0;
+
+    for index in 0..nodes.len() {
+        let node_width = TASK_GRAPH_NODE_WIDTH;
+        let next_width = if row_width == 0.0 {
+            node_width
+        } else {
+            row_width + TASK_GRAPH_HORIZONTAL_GAP + node_width
+        };
+        if !rows.last().is_some_and(|row| row.is_empty()) && row_width > 0.0 && next_width > TASK_GRAPH_MAX_ROW_WIDTH {
+            rows.push(Vec::new());
+            row_width = 0.0;
+        }
+        if rows.is_empty() {
+            rows.push(Vec::new());
+        }
+        let current_row = rows.last_mut().unwrap();
+        if current_row.is_empty() {
+            row_width = node_width;
+        } else {
+            row_width += TASK_GRAPH_HORIZONTAL_GAP + node_width;
+        }
+        current_row.push(index);
+    }
+
+    let mut y = TASK_GRAPH_ORIGIN_Y;
+    for (row_index, row) in rows.into_iter().enumerate() {
+        let mut visual_order = row.clone();
+        if row_index % 2 == 1 {
+            visual_order.reverse();
+        }
+
+        let mut x = TASK_GRAPH_ORIGIN_X;
+        let row_height = row
+            .iter()
+            .map(|index| task_graph_node_visual_height(&nodes[*index]))
+            .fold(0.0f32, f32::max);
+        for index in visual_order {
+            nodes[index].position = Some(GraphPosition { x, y });
+            x += TASK_GRAPH_NODE_WIDTH + TASK_GRAPH_HORIZONTAL_GAP;
+        }
+        y += row_height + TASK_GRAPH_VERTICAL_GAP;
+    }
+}
+
+fn task_graph_node_visual_height(node: &NodeDefinition) -> f32 {
+    let _ = node;
+    TASK_GRAPH_BASE_NODE_HEIGHT
 }
 
 pub(crate) struct QqChatBrainObserver {


### PR DESCRIPTION
  Moves task output rendering from node panels to output-port/link summaries, adds clickable detail dialogs and a canvas visibility toggle, and updates QQ task snapshots to store
  outputs by port name.