### PR TITLE
Add workspace change tracking, user review

### DIFF
--- a/model_inference/src/system_config.rs
+++ b/model_inference/src/system_config.rs
@@ -67,6 +67,8 @@ pub struct HttpStreamServiceConfig {
 pub struct WorkspaceAgentServiceConfig {
     #[serde(default)]
     pub llm_ref_id: Option<String>,
+    #[serde(default)]
+    pub agents_md_enabled: bool,
     #[serde(default = "default_workspace_default_tools_enabled")]
     pub default_tools_enabled: std::collections::HashMap<String, bool>,
 }

--- a/src/api/agents_md.rs
+++ b/src/api/agents_md.rs
@@ -1,0 +1,121 @@
+//! AGENTS.md management for Workspace Agent Service.
+//!
+//! Lists, creates, edits, and deletes the `AGENTS.md` files that a Workspace Agent can
+//! reference in its system prompt. Files are addressed by a location key rather than a raw
+//! path, so every write is confined to one of the three candidate directories.
+
+use std::fs;
+
+use salvo::prelude::*;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use zihuan_service::agent::workspace_agent_service::{
+    agents_md_candidates, AgentsMdCandidate, AgentsMdLocation,
+};
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentsMdFile {
+    pub key: String,
+    pub path: String,
+    pub exists: bool,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SaveAgentsMdRequest {
+    pub key: String,
+    pub content: String,
+}
+
+/// Lists the candidate AGENTS.md files in priority order, including their current content.
+#[handler]
+pub async fn list_agents_md(req: &mut Request, res: &mut Response) {
+    let workspace_path = query_workspace_path(req);
+    let files = agents_md_candidates(workspace_path.as_deref())
+        .into_iter()
+        .map(|candidate| {
+            let content = if candidate.exists {
+                fs::read_to_string(&candidate.path).unwrap_or_default()
+            } else {
+                String::new()
+            };
+            AgentsMdFile {
+                key: candidate.location.key().to_string(),
+                path: candidate.path.to_string_lossy().to_string(),
+                exists: candidate.exists,
+                content,
+            }
+        })
+        .collect::<Vec<_>>();
+    res.render(Json(json!({ "files": files })));
+}
+
+/// Creates or overwrites the AGENTS.md file at the requested location.
+#[handler]
+pub async fn save_agents_md(req: &mut Request, res: &mut Response) {
+    let body: SaveAgentsMdRequest = match req.parse_json().await {
+        Ok(body) => body,
+        Err(err) => {
+            return render_error(res, StatusCode::BAD_REQUEST, format!("请求体解析失败: {err}"));
+        }
+    };
+    let workspace_path = query_workspace_path(req);
+    let candidate = match resolve_candidate(&body.key, workspace_path.as_deref()) {
+        Some(candidate) => candidate,
+        None => {
+            return render_error(res, StatusCode::BAD_REQUEST, format!("无效的 AGENTS.md 位置: {}", body.key));
+        }
+    };
+    if let Some(parent) = candidate.path.parent() {
+        if let Err(err) = fs::create_dir_all(parent) {
+            return render_error(res, StatusCode::INTERNAL_SERVER_ERROR, format!("创建目录失败: {err}"));
+        }
+    }
+    if let Err(err) = fs::write(&candidate.path, &body.content) {
+        return render_error(res, StatusCode::INTERNAL_SERVER_ERROR, format!("写入失败: {err}"));
+    }
+    res.render(Json(json!({ "ok": true, "path": candidate.path.to_string_lossy().to_string() })));
+}
+
+/// Deletes the AGENTS.md file at the requested location, if it exists.
+#[handler]
+pub async fn delete_agents_md(req: &mut Request, res: &mut Response) {
+    let key = req.query::<String>("key").unwrap_or_default();
+    let workspace_path = query_workspace_path(req);
+    let candidate = match resolve_candidate(&key, workspace_path.as_deref()) {
+        Some(candidate) => candidate,
+        None => {
+            return render_error(res, StatusCode::BAD_REQUEST, format!("无效的 AGENTS.md 位置: {key}"));
+        }
+    };
+    if candidate.exists {
+        if let Err(err) = fs::remove_file(&candidate.path) {
+            return render_error(res, StatusCode::INTERNAL_SERVER_ERROR, format!("删除失败: {err}"));
+        }
+    }
+    res.render(Json(json!({ "ok": true, "path": candidate.path.to_string_lossy().to_string() })));
+}
+
+fn query_workspace_path(req: &Request) -> Option<String> {
+    req.query::<String>("workspace_path")
+        .map(|path| path.trim().to_string())
+        .filter(|path| !path.is_empty())
+}
+
+fn resolve_candidate(key: &str, workspace_path: Option<&str>) -> Option<AgentsMdCandidate> {
+    let location = match key {
+        "workspace" => AgentsMdLocation::Workspace,
+        "executable" => AgentsMdLocation::Executable,
+        "home" => AgentsMdLocation::Home,
+        _ => return None,
+    };
+    agents_md_candidates(workspace_path)
+        .into_iter()
+        .find(|candidate| candidate.location == location)
+}
+
+fn render_error(res: &mut Response, status: StatusCode, message: String) {
+    res.status_code(status);
+    res.render(Json(json!({ "error": message })));
+}

--- a/src/api/chat.rs
+++ b/src/api/chat.rs
@@ -25,6 +25,8 @@ use zihuan_core::llm::{LLMMessage, MessageRole, StreamToken};
 use zihuan_core::message_part::MessagePart;
 use zihuan_core::workspace::{normalized_workspace_path, AskUserRequest};
 
+use crate::api::workspace_changes;
+
 const CHAT_HISTORY_DIR_NAME: &str = "chat_history";
 const APP_DIR_NAME: &str = "zihuan-next_aibot";
 const CHAT_STREAM_MAX_BODY_BYTES: usize = 64 * 1024 * 1024;
@@ -47,6 +49,7 @@ const CHAT_FORK_METADATA_SUFFIX: &str = ".fork.json";
 struct SseBrainObserver {
     event_tx: mpsc::UnboundedSender<Value>,
     message_id: String,
+    change_recorder: Arc<workspace_changes::WorkspaceChangeRecorder>,
 }
 
 impl BrainObserver for SseBrainObserver {
@@ -59,6 +62,9 @@ impl BrainObserver for SseBrainObserver {
             "arguments": arguments,
         });
         let _ = self.event_tx.send(event);
+        if let Some(operation) = workspace_changes::operation_for_tool(name) {
+            self.change_recorder.start(call_id, operation, arguments);
+        }
     }
 
     fn on_tool_output(&self, name: &str, call_id: &str, stream: &str, chunk: &str) {
@@ -82,6 +88,13 @@ impl BrainObserver for SseBrainObserver {
             "result": result,
         });
         let _ = self.event_tx.send(event);
+        if let Some(change) = self.change_recorder.finish(call_id, result) {
+            let _ = self.event_tx.send(json!({
+                "type": "workspace_change",
+                "message_id": self.message_id,
+                "change": change,
+            }));
+        }
     }
 }
 
@@ -944,6 +957,10 @@ async fn execute_chat_streaming(
     let observer: Arc<dyn BrainObserver> = Arc::new(SseBrainObserver {
         event_tx,
         message_id: assistant_message_id.clone(),
+        change_recorder: workspace_changes::WorkspaceChangeRecorder::new(
+            session_id.clone(),
+            effective_workspace_path.clone(),
+        ),
     });
 
     let chat_workspace_path = effective_workspace_path.clone();

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -15,6 +15,7 @@ pub mod state;
 pub mod task_store;
 pub mod themes;
 pub mod ws;
+pub mod workspace_changes;
 
 use std::sync::Arc;
 
@@ -212,6 +213,9 @@ pub fn build_router(state: Arc<AppState>, broadcast: WsBroadcast, canonical_loca
                 .push(Router::with_path("sessions").get(chat::list_chat_sessions))
                 .push(Router::with_path("sessions/<session_id>/fork").post(chat::fork_chat_session))
                 .push(Router::with_path("sessions/<session_id>").delete(chat::delete_chat_session))
+                .push(Router::with_path("sessions/<session_id>/changes").get(workspace_changes::list_workspace_changes))
+                .push(Router::with_path("sessions/<session_id>/changes/<change_id>/accept").post(workspace_changes::accept_workspace_change))
+                .push(Router::with_path("sessions/<session_id>/changes/<change_id>/cancel").post(workspace_changes::cancel_workspace_change))
                 .push(
                     Router::with_path("sessions/<session_id>/messages")
                         .get(chat::get_chat_session_messages),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -15,6 +15,7 @@ pub mod state;
 pub mod task_store;
 pub mod themes;
 pub mod ws;
+pub mod agents_md;
 pub mod workspace_changes;
 
 use std::sync::Arc;
@@ -220,6 +221,12 @@ pub fn build_router(state: Arc<AppState>, broadcast: WsBroadcast, canonical_loca
                     Router::with_path("sessions/<session_id>/messages")
                         .get(chat::get_chat_session_messages),
                 ),
+        )
+        .push(
+            Router::with_path("agents-md")
+                .get(agents_md::list_agents_md)
+                .post(agents_md::save_agents_md)
+                .delete(agents_md::delete_agents_md),
         )
         // Workflows directory
         .push(Router::with_path("workflow_set").get(file_io::list_workflows))

--- a/src/api/workspace_changes.rs
+++ b/src/api/workspace_changes.rs
@@ -1,0 +1,412 @@
+//! Workspace file-change tracking, persistence, and user-controlled rollback.
+//!
+//! This module implements the change-review layer for Workspace Agent file operations. The
+//! underlying tools still write to disk immediately; this module records what happened after
+//! the write so the dashboard can present a reviewable change without delaying the agent loop.
+//!
+//! mechanism:
+//!
+//! 1. `SseBrainObserver::on_tool_start` identifies a mutating workspace tool and calls
+//!    [`WorkspaceChangeRecorder::start`]. The recorder resolves every affected path and captures
+//!    its complete before-snapshot.
+//! 2. The workspace tool executes normally and writes to disk.
+//! 3. `SseBrainObserver::on_tool_finish` passes the tool result to
+//!    [`WorkspaceChangeRecorder::finish`]. Failed tool results and no-op writes are ignored;
+//!    successful writes are compared with a new after-snapshot.
+//! 4. A [`WorkspaceChangeRecord`] is created, persisted, and emitted as a structured SSE event.
+//!    The frontend uses that event to update the compact review panel and the detail dialog.
+//! 5. Consecutive pending edits for the same file are folded into one logical record. The first
+//!    before-snapshot is retained, while the latest after-snapshot, fingerprint, line counts, and
+//!    diff replace the previous values. Accepting or canceling a record ends that merge window.
+//! 6. Accept only changes the record state. Cancel first compares the current filesystem state
+//!    with the recorded after-fingerprint; if another process changed the file, rollback is
+//!    rejected to avoid overwriting external work. Otherwise the before-snapshot is restored.
+//!
+//! Metadata is stored per session as JSON, while full snapshots are stored in sidecar JSON files
+//! keyed by change ID. This keeps the chat history format independent from binary file contents
+//! and allows pending changes to be reconstructed after a page refresh or server restart.
+//!
+//! Copy and move operations are represented as one record containing both source and destination
+//! paths. Directory snapshots recursively capture entries, so restoration can recreate files,
+//! directories, and the original non-existent state.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use salvo::prelude::*;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use uuid::Uuid;
+use zihuan_core::error::{Error, Result};
+use zihuan_core::system_config::app_data_dir;
+
+const CHANGE_DIR_NAME: &str = "workspace_changes";
+
+/// Lists the pending filesystem changes for a chat session.
+///
+/// This endpoint is used during session restore and page refresh. Accepted and canceled records
+/// remain persisted for auditability but are filtered out by [`pending`].
+#[handler]
+pub async fn list_workspace_changes(req: &mut Request, res: &mut Response) {
+    let session_id = req.param::<String>("session_id").unwrap_or_default();
+    match pending(&session_id) {
+        Ok(changes) => res.render(Json(json!({ "changes": changes }))),
+        Err(err) => render_internal_error(res, err),
+    }
+}
+
+/// Accepts one change record while leaving the already-written filesystem untouched.
+#[handler]
+pub async fn accept_workspace_change(req: &mut Request, res: &mut Response) {
+    let session_id = req.param::<String>("session_id").unwrap_or_default();
+    let change_id = req.param::<String>("change_id").unwrap_or_default();
+    match accept(&session_id, &change_id) {
+        Ok(change) => res.render(Json(json!({ "change": change }))),
+        Err(err) => render_internal_error(res, err),
+    }
+}
+
+/// Cancels one change record and restores its before-snapshot when conflict checks pass.
+///
+/// A filesystem fingerprint mismatch is returned as HTTP 409 so the frontend can keep the
+/// record visible and explain that an external modification must be resolved manually.
+#[handler]
+pub async fn cancel_workspace_change(req: &mut Request, res: &mut Response) {
+    let session_id = req.param::<String>("session_id").unwrap_or_default();
+    let change_id = req.param::<String>("change_id").unwrap_or_default();
+    match cancel(&session_id, &change_id) {
+        Ok(change) => res.render(Json(json!({ "change": change }))),
+        Err(err) => {
+            res.status_code(StatusCode::CONFLICT);
+            res.render(Json(json!({ "error": err.to_string() })));
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceChangeOperation {
+    /// A path did not exist before the operation and now contains a file or directory.
+    Create,
+    /// Existing file content was replaced in place.
+    Edit,
+    /// A file or directory was removed.
+    Delete,
+    /// A source was copied to a destination, possibly replacing the destination.
+    Copy,
+    /// A source was moved or renamed to a destination, possibly replacing the destination.
+    Move,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceChangeStatus {
+    /// The change is still visible in the dashboard review panel and can be handled by the user.
+    Pending,
+    /// The user accepted the already-written filesystem state.
+    Accepted,
+    /// The user canceled the change and the before-snapshot was restored.
+    Canceled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceDiffLine {
+    /// Either `added` or `removed`.
+    pub kind: String,
+    /// The source line captured from the before or after snapshot.
+    pub line: String,
+}
+
+/// One serialized file or directory entry inside a path snapshot.
+///
+/// File bytes are hex encoded instead of interpreted as UTF-8, which makes rollback safe for
+/// arbitrary file contents. Directory entries only need their relative path and directory flag.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SnapshotEntry {
+    relative_path: String,
+    is_directory: bool,
+    content_hex: Option<String>,
+}
+
+/// Complete state of one affected path before or after a tool call.
+///
+/// The path itself is absolute for reliable restoration, while public records expose workspace-
+/// relative paths for display. `exists` distinguishes a missing path from an empty directory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PathSnapshot {
+    path: String,
+    exists: bool,
+    entries: Vec<SnapshotEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceChangeRecord {
+    /// Stable identifier used by SSE events and Accept/Cancel endpoints.
+    pub change_id: String,
+    /// Chat session that owns this review record.
+    pub session_id: String,
+    /// Workspace operation that produced the record.
+    pub operation: WorkspaceChangeOperation,
+    /// Workspace-relative display paths affected by the operation.
+    pub paths: Vec<String>,
+    /// Primary path shown in compact lists and as the file grouping key.
+    pub display_path: String,
+    /// Number of lines present only in the after-state summary.
+    pub added_lines: usize,
+    /// Number of lines present only in the before-state summary.
+    pub removed_lines: usize,
+    /// Fingerprint of all before snapshots, used for diagnostics and auditing.
+    pub before_fingerprint: String,
+    /// Fingerprint of all after snapshots, used to detect external changes before rollback.
+    pub after_fingerprint: String,
+    /// Current review state.
+    pub status: WorkspaceChangeStatus,
+    /// Number of edit tool calls folded into this logical record.
+    pub merged_count: usize,
+    /// Coarse unified-style line list used by the dashboard detail dialog.
+    #[serde(default)]
+    pub diff: Vec<WorkspaceDiffLine>,
+    /// Private recovery data retained in memory and in the change sidecar file.
+    #[serde(skip)]
+    before: Vec<PathSnapshot>,
+    /// Private post-write state used for conflict detection.
+    #[serde(skip)]
+    after: Vec<PathSnapshot>,
+}
+
+/// Temporary correlation state held between observer start and finish callbacks.
+#[derive(Debug, Clone)]
+struct PendingOperation {
+    session_id: String,
+    operation: WorkspaceChangeOperation,
+    paths: Vec<PathBuf>,
+    before: Vec<PathSnapshot>,
+}
+
+static RECORDS: OnceLock<Mutex<HashMap<String, Vec<WorkspaceChangeRecord>>>> = OnceLock::new();
+static STARTED: OnceLock<Mutex<HashMap<String, PendingOperation>>> = OnceLock::new();
+
+fn records() -> &'static Mutex<HashMap<String, Vec<WorkspaceChangeRecord>>> {
+    RECORDS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn started() -> &'static Mutex<HashMap<String, PendingOperation>> {
+    STARTED.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub struct WorkspaceChangeRecorder {
+    pub session_id: String,
+    workspace_path: Option<PathBuf>,
+}
+
+impl WorkspaceChangeRecorder {
+    /// Creates a recorder for one chat session and loads any persisted records for that session.
+    ///
+    /// The recorder is request-scoped and shared with the Brain observer through an `Arc`. The
+    /// session-level store is global so the REST handlers can access the same records later.
+    pub fn new(session_id: impl Into<String>, workspace_path: Option<String>) -> Arc<Self> {
+        let recorder = Arc::new(Self { session_id: session_id.into(), workspace_path: workspace_path.map(PathBuf::from) });
+        let _ = load_session(&recorder.session_id);
+        recorder
+    }
+
+    /// Captures the filesystem state before a mutating tool starts.
+    ///
+    /// The tool call ID is the temporary correlation key. It is removed when `finish` is called,
+    /// so a failed or disconnected tool call cannot accidentally be reused by a later operation.
+    pub fn start(&self, call_id: &str, operation: WorkspaceChangeOperation, arguments: &Value) {
+        let paths = operation_paths(&operation, arguments)
+            .into_iter()
+            .filter_map(|path| resolve_path(self.workspace_path.as_deref(), &path))
+            .collect::<Vec<_>>();
+        let before = paths.iter().map(|path| snapshot(path)).collect::<Vec<_>>();
+        started().lock().expect("workspace change lock poisoned").insert(call_id.to_string(), PendingOperation {
+            session_id: self.session_id.clone(), operation, paths, before,
+        });
+    }
+
+    /// Finalizes a tool call after the tool has written to disk.
+    ///
+    /// A valid successful JSON result must contain `{"ok": true}`. The method then snapshots the
+    /// affected paths again, ignores no-op changes, merges compatible pending edits, persists the
+    /// record and returns it for SSE emission. Persistence errors are intentionally best-effort
+    /// here because the existing tool result must not be changed after the tool has completed.
+    pub fn finish(&self, call_id: &str, result: &str) -> Option<WorkspaceChangeRecord> {
+        let operation = started().lock().ok()?.remove(call_id)?;
+        let result_json: Value = serde_json::from_str(result).ok()?;
+        if result_json.get("ok").and_then(Value::as_bool) != Some(true) {
+            return None;
+        }
+        let after = operation.paths.iter().map(|path| snapshot(path)).collect::<Vec<_>>();
+        if snapshots_equal(&operation.before, &after) {
+            return None;
+        }
+        let record = WorkspaceChangeRecord {
+            change_id: Uuid::new_v4().to_string(),
+            session_id: operation.session_id.clone(),
+            operation: operation.operation,
+            paths: operation.paths.iter().map(|path| display_path(self.workspace_path.as_deref(), path)).collect(),
+            display_path: operation.paths.first().map(|path| display_path(self.workspace_path.as_deref(), path)).unwrap_or_default(),
+            added_lines: line_delta(&operation.before, &after).0,
+            removed_lines: line_delta(&operation.before, &after).1,
+            before_fingerprint: fingerprint(&operation.before),
+            after_fingerprint: fingerprint(&after),
+            status: WorkspaceChangeStatus::Pending,
+            merged_count: 1,
+            diff: build_diff(&operation.before, &after),
+            before: operation.before,
+            after,
+        };
+
+        let mut all = records().lock().expect("workspace change lock poisoned");
+        let list = all.entry(self.session_id.clone()).or_default();
+        if let Some(index) = list.iter().rposition(|item| matches!(item.status, WorkspaceChangeStatus::Pending) && item.paths == record.paths && matches!(item.operation, WorkspaceChangeOperation::Edit) && matches!(record.operation, WorkspaceChangeOperation::Edit)) {
+            let previous = &mut list[index];
+            previous.after = record.after.clone();
+            previous.after_fingerprint = record.after_fingerprint.clone();
+            previous.added_lines += record.added_lines;
+            previous.removed_lines += record.removed_lines;
+            previous.diff = record.diff.clone();
+            previous.merged_count += 1;
+            let output = previous.clone();
+            persist_snapshot(&output).ok();
+            persist_session(&self.session_id, list).ok();
+            return Some(output);
+        }
+        persist_snapshot(&record).ok();
+        list.push(record.clone());
+        persist_session(&self.session_id, list).ok();
+        Some(record)
+    }
+}
+
+/// Returns all pending changes belonging to a chat session.
+///
+/// Loading is lazy: the first call reconstructs record metadata and private snapshots from the
+/// session JSON and change sidecars. The frontend uses this endpoint when opening or refreshing
+/// a conversation.
+pub fn pending(session_id: &str) -> Result<Vec<WorkspaceChangeRecord>> {
+    load_session(session_id)?;
+    let all = records().lock().map_err(|_| Error::StringError("workspace change lock poisoned".to_string()))?;
+    Ok(all.get(session_id).cloned().unwrap_or_default().into_iter().filter(|item| matches!(item.status, WorkspaceChangeStatus::Pending)).collect())
+}
+
+/// Marks one pending change as accepted without touching the filesystem.
+pub fn accept(session_id: &str, change_id: &str) -> Result<WorkspaceChangeRecord> {
+    update_status(session_id, change_id, WorkspaceChangeStatus::Accepted, false)
+}
+
+/// Attempts to cancel one pending change and restore its before-snapshot.
+///
+/// Rollback is guarded by the after-fingerprint. A mismatch means another operation changed one
+/// of the affected paths after the agent write, so the method returns a conflict error instead of
+/// overwriting that newer state.
+pub fn cancel(session_id: &str, change_id: &str) -> Result<WorkspaceChangeRecord> {
+    load_session(session_id)?;
+    let mut all = records().lock().map_err(|_| Error::StringError("workspace change lock poisoned".to_string()))?;
+    let record = all.get_mut(session_id).and_then(|items| items.iter_mut().find(|item| item.change_id == change_id)).ok_or_else(|| Error::ValidationError("workspace change not found".to_string()))?;
+    if !matches!(record.status, WorkspaceChangeStatus::Pending) { return Ok(record.clone()); }
+    let current = record.after.iter().map(|item| snapshot(Path::new(&item.path))).collect::<Vec<_>>();
+    if fingerprint(&current) != record.after_fingerprint { return Err(Error::ValidationError("文件已被其他操作修改，无法自动回滚".to_string())); }
+    for snapshot_item in &record.before { restore(snapshot_item)?; }
+    record.status = WorkspaceChangeStatus::Canceled;
+    let output = record.clone();
+    let items = all.get(session_id).unwrap();
+    persist_session(session_id, items)?;
+    Ok(output)
+}
+
+fn update_status(session_id: &str, change_id: &str, status: WorkspaceChangeStatus, _write: bool) -> Result<WorkspaceChangeRecord> {
+    load_session(session_id)?;
+    let mut all = records().lock().map_err(|_| Error::StringError("workspace change lock poisoned".to_string()))?;
+    let items = all.get_mut(session_id).ok_or_else(|| Error::ValidationError("workspace change not found".to_string()))?;
+    let record = items.iter_mut().find(|item| item.change_id == change_id).ok_or_else(|| Error::ValidationError("workspace change not found".to_string()))?;
+    if matches!(record.status, WorkspaceChangeStatus::Pending) { record.status = status; }
+    let output = record.clone();
+    persist_session(session_id, items)?;
+    Ok(output)
+}
+
+fn operation_paths(operation: &WorkspaceChangeOperation, args: &Value) -> Vec<String> {
+    match operation {
+        WorkspaceChangeOperation::Create | WorkspaceChangeOperation::Edit | WorkspaceChangeOperation::Delete => args.get("path").and_then(Value::as_str).map(|v| vec![v.to_string()]).unwrap_or_default(),
+        WorkspaceChangeOperation::Copy | WorkspaceChangeOperation::Move => [args.get("src").and_then(Value::as_str), args.get("dest").and_then(Value::as_str)].into_iter().flatten().map(ToOwned::to_owned).collect(),
+    }
+}
+
+/// Maps a Brain tool name to the set of operations that can create review records.
+///
+/// `exec_cmd` is deliberately excluded because arbitrary command side effects cannot be safely
+/// reconstructed from its output.
+pub fn operation_for_tool(name: &str) -> Option<WorkspaceChangeOperation> {
+    match name { "create_file" => Some(WorkspaceChangeOperation::Create), "edit_file" => Some(WorkspaceChangeOperation::Edit), "delete_file" => Some(WorkspaceChangeOperation::Delete), "copy_file" => Some(WorkspaceChangeOperation::Copy), "move_file" => Some(WorkspaceChangeOperation::Move), _ => None }
+}
+
+fn resolve_path(workspace: Option<&Path>, raw: &str) -> Option<PathBuf> { let path = PathBuf::from(raw); Some(if path.is_absolute() { path } else { workspace?.join(path) }) }
+fn display_path(workspace: Option<&Path>, path: &Path) -> String { workspace.and_then(|root| path.strip_prefix(root).ok()).unwrap_or(path).to_string_lossy().replace('\\', "/") }
+
+/// Captures a path as a deterministic, serializable snapshot.
+///
+/// Files are stored as hex-encoded bytes so binary data and platform-specific line endings survive
+/// a rollback unchanged. Directories are represented as recursive relative entries. A missing
+/// path has `exists == false` and an empty entry list, which lets restoration remove a newly
+/// created path rather than writing an empty placeholder.
+fn snapshot(path: &Path) -> PathSnapshot {
+    let mut entries = Vec::new();
+    if path.is_dir() { collect_entries(path, path, &mut entries); }
+    else if path.is_file() { entries.push(SnapshotEntry { relative_path: String::new(), is_directory: false, content_hex: fs::read(path).ok().map(|bytes| hex_encode(&bytes)) }); }
+    PathSnapshot { path: path.to_string_lossy().to_string(), exists: path.exists(), entries }
+}
+
+/// Recursively appends directory entries to a path snapshot.
+fn collect_entries(root: &Path, current: &Path, entries: &mut Vec<SnapshotEntry>) { if let Ok(read_dir) = fs::read_dir(current) { for item in read_dir.flatten() { let path = item.path(); let relative_path = path.strip_prefix(root).unwrap_or(&path).to_string_lossy().to_string(); if path.is_dir() { entries.push(SnapshotEntry { relative_path: relative_path.clone(), is_directory: true, content_hex: None }); collect_entries(root, &path, entries); } else if path.is_file() { entries.push(SnapshotEntry { relative_path, is_directory: false, content_hex: fs::read(&path).ok().map(|bytes| hex_encode(&bytes)) }); } } } }
+fn snapshots_equal(before: &[PathSnapshot], after: &[PathSnapshot]) -> bool { fingerprint(before) == fingerprint(after) }
+
+/// Produces the stable fingerprint used to compare complete multi-path states.
+fn fingerprint(items: &[PathSnapshot]) -> String { let json = serde_json::to_vec(items).unwrap_or_default(); hex_encode(&json) }
+fn line_delta(before: &[PathSnapshot], after: &[PathSnapshot]) -> (usize, usize) { let old = line_count(before); let new = line_count(after); (new.saturating_sub(old), old.saturating_sub(new)) }
+fn line_count(items: &[PathSnapshot]) -> usize { items.iter().flat_map(|item| item.entries.iter()).filter_map(|entry| entry.content_hex.as_deref()).map(|hex| String::from_utf8_lossy(&hex_decode(hex)).lines().count()).sum() }
+fn build_diff(before: &[PathSnapshot], after: &[PathSnapshot]) -> Vec<WorkspaceDiffLine> {
+    let old = snapshot_lines(before);
+    let new = snapshot_lines(after);
+    let mut diff = old.into_iter().map(|line| WorkspaceDiffLine { kind: "removed".to_string(), line }).collect::<Vec<_>>();
+    diff.extend(new.into_iter().map(|line| WorkspaceDiffLine { kind: "added".to_string(), line }));
+    diff
+}
+fn snapshot_lines(items: &[PathSnapshot]) -> Vec<String> {
+    items.iter().flat_map(|item| item.entries.iter()).filter_map(|entry| entry.content_hex.as_deref()).flat_map(|hex| String::from_utf8_lossy(&hex_decode(hex)).lines().map(ToOwned::to_owned).collect::<Vec<_>>()).collect()
+}
+fn hex_encode(bytes: &[u8]) -> String { bytes.iter().map(|byte| format!("{byte:02x}")).collect() }
+fn hex_decode(value: &str) -> Vec<u8> { value.as_bytes().chunks(2).filter_map(|chunk| u8::from_str_radix(std::str::from_utf8(chunk).ok()?, 16).ok()).collect() }
+
+fn restore(snapshot: &PathSnapshot) -> Result<()> {
+    let path = PathBuf::from(&snapshot.path);
+    if path.exists() { if path.is_dir() { fs::remove_dir_all(&path)?; } else { fs::remove_file(&path)?; } }
+    if !snapshot.exists { return Ok(()); }
+    if snapshot.entries.len() == 1 && snapshot.entries[0].relative_path.is_empty() { if let Some(parent) = path.parent() { fs::create_dir_all(parent)?; } fs::write(path, hex_decode(snapshot.entries[0].content_hex.as_deref().unwrap_or_default()))?; return Ok(()); }
+    fs::create_dir_all(&path)?;
+    for entry in &snapshot.entries { let target = path.join(&entry.relative_path); if entry.is_directory { fs::create_dir_all(target)?; } else { if let Some(parent) = target.parent() { fs::create_dir_all(parent)?; } fs::write(target, hex_decode(entry.content_hex.as_deref().unwrap_or_default()))?; } }
+    Ok(())
+}
+
+/// Returns the application storage location for change metadata and snapshot sidecars.
+fn storage_dir() -> PathBuf { app_data_dir().join(CHANGE_DIR_NAME) }
+
+/// Returns the per-session metadata file path.
+fn session_file(session_id: &str) -> PathBuf { storage_dir().join(format!("{session_id}.json")) }
+
+/// Stores private before/after snapshots separately from the public record metadata.
+fn persist_snapshot(record: &WorkspaceChangeRecord) -> Result<()> { let path = storage_dir().join(format!("{}-snapshot.json", record.change_id)); fs::create_dir_all(storage_dir())?; let data = serde_json::to_vec(&(record.before.clone(), record.after.clone())).map_err(|e| Error::StringError(e.to_string()))?; fs::write(path, data)?; Ok(()) }
+
+/// Writes the session's complete record list so status changes and merge results survive restart.
+fn persist_session(session_id: &str, items: &[WorkspaceChangeRecord]) -> Result<()> { fs::create_dir_all(storage_dir())?; let data = serde_json::to_vec_pretty(items).map_err(|e| Error::StringError(e.to_string()))?; fs::write(session_file(session_id), data)?; Ok(()) }
+
+/// Lazily reconstructs a session from its metadata file and snapshot sidecars.
+fn load_session(session_id: &str) -> Result<()> { let mut all = records().lock().map_err(|_| Error::StringError("workspace change lock poisoned".to_string()))?; if all.contains_key(session_id) { return Ok(()); } let path = session_file(session_id); if !path.exists() { all.insert(session_id.to_string(), Vec::new()); return Ok(()); } let mut items: Vec<WorkspaceChangeRecord> = serde_json::from_slice(&fs::read(path)?).map_err(|e| Error::StringError(e.to_string()))?; for item in &mut items { let snapshot_path = storage_dir().join(format!("{}-snapshot.json", item.change_id)); if snapshot_path.exists() { if let Ok((before, after)) = serde_json::from_slice(&fs::read(snapshot_path)?) { item.before = before; item.after = after; } } } all.insert(session_id.to_string(), items); Ok(()) }
+
+fn render_internal_error(res: &mut Response, err: impl ToString) {
+    res.status_code(StatusCode::INTERNAL_SERVER_ERROR);
+    res.render(Json(json!({ "error": err.to_string() })));
+}

--- a/src/setup_orchestrator/config_factory.rs
+++ b/src/setup_orchestrator/config_factory.rs
@@ -328,6 +328,7 @@ fn build_workspace_agent_service(id: &str, name: &str, llm_ref_id: Option<String
         name: name.to_string(),
         agent_type: AgentType::Workspace(WorkspaceAgentServiceConfig {
             llm_ref_id,
+            agents_md_enabled: true,
             default_tools_enabled: default_workspace_tools(),
         }),
         enabled: true,

--- a/tests/workspace_changes.rs
+++ b/tests/workspace_changes.rs
@@ -1,0 +1,56 @@
+#[path = "../src/api/workspace_changes.rs"]
+mod workspace_changes;
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use workspace_changes::{accept, cancel, WorkspaceChangeOperation, WorkspaceChangeRecorder};
+
+fn temp_workspace() -> PathBuf {
+    let suffix = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+    std::env::temp_dir().join(format!("zihuan-workspace-change-{suffix}"))
+}
+
+/// Purpose: Verify consecutive edits to one file share one merged change record and can be rolled back atomically.
+/// TestData: A two-line UTF-8 file, followed by two successful edits changing one line each.
+#[test]
+fn edit_changes_merge_and_cancel_restores_original_content() {
+    let root = temp_workspace();
+    let session_id = format!("test-session-{}", root.file_name().unwrap().to_string_lossy());
+    fs::create_dir_all(&root).unwrap();
+    let path = root.join("note.txt");
+    fs::write(&path, "one\ntwo\n").unwrap();
+    let recorder = WorkspaceChangeRecorder::new(&session_id, Some(root.to_string_lossy().to_string()));
+    let args = serde_json::json!({ "path": "note.txt" });
+
+    recorder.start("first", WorkspaceChangeOperation::Edit, &args);
+    fs::write(&path, "ONE\ntwo\n").unwrap();
+    let first = recorder.finish("first", r#"{"ok":true}"#).unwrap();
+    recorder.start("second", WorkspaceChangeOperation::Edit, &args);
+    fs::write(&path, "ONE\nTWO\n").unwrap();
+    let second = recorder.finish("second", r#"{"ok":true}"#).unwrap();
+
+    assert_eq!(first.change_id, second.change_id);
+    assert_eq!(second.merged_count, 2);
+    cancel(&session_id, &second.change_id).unwrap();
+    assert_eq!(fs::read_to_string(&path).unwrap(), "one\ntwo\n");
+    let _ = fs::remove_dir_all(root);
+}
+
+/// Purpose: Verify Accept marks a change as handled without writing or altering the changed file.
+/// TestData: A newly created file containing the text `kept` and one pending create operation.
+#[test]
+fn accept_does_not_change_disk() {
+    let root = temp_workspace();
+    let session_id = format!("accept-session-{}", root.file_name().unwrap().to_string_lossy());
+    fs::create_dir_all(&root).unwrap();
+    let path = root.join("created.txt");
+    let recorder = WorkspaceChangeRecorder::new(&session_id, Some(root.to_string_lossy().to_string()));
+    recorder.start("create", WorkspaceChangeOperation::Create, &serde_json::json!({ "path": "created.txt" }));
+    fs::write(&path, "kept").unwrap();
+    let change = recorder.finish("create", r#"{"ok":true}"#).unwrap();
+    accept(&session_id, &change.change_id).unwrap();
+    assert_eq!(fs::read_to_string(&path).unwrap(), "kept");
+    let _ = fs::remove_dir_all(root);
+}

--- a/webui/src/admin/admin.scss
+++ b/webui/src/admin/admin.scss
@@ -1,3 +1,4 @@
 @use "./styles/base";
 @use "./styles/tdesign-theme";
 @use "./styles/workspace-change";
+@use "./styles/agents-md";

--- a/webui/src/admin/admin.scss
+++ b/webui/src/admin/admin.scss
@@ -1,2 +1,3 @@
 @use "./styles/base";
 @use "./styles/tdesign-theme";
+@use "./styles/workspace-change";

--- a/webui/src/admin/composables/useChat.ts
+++ b/webui/src/admin/composables/useChat.ts
@@ -13,6 +13,7 @@ import {
   type ChatMessagePart,
   type ChatMessageBranch,
   type LlmConfig,
+  type WorkspaceChange,
 } from "../../api/client";
 import {
   formatTime,
@@ -438,6 +439,22 @@ const selectedAgentAvatarFallback = computed(() => {
   return agentInitial(name);
 });
 const pendingAskUser = ref<PendingAskUser | null>(null);
+const workspaceChanges = ref<WorkspaceChange[]>([]);
+const selectedWorkspaceChangeId = ref<string | null>(null);
+const workspaceChangeDialogOpen = ref(false);
+const workspaceChangeError = ref("");
+const selectedWorkspaceChange = computed(() =>
+  workspaceChanges.value.find((item) => item.change_id === selectedWorkspaceChangeId.value) ?? workspaceChanges.value[0] ?? null,
+);
+const workspaceFileGroups = computed(() => {
+  const groups = new Map<string, WorkspaceChange[]>();
+  for (const change of workspaceChanges.value) {
+    const group = groups.get(change.display_path) ?? [];
+    group.push(change);
+    groups.set(change.display_path, group);
+  }
+  return Array.from(groups, ([path, changes]) => ({ path, changes }));
+});
 const askUserAnswer = ref("");
 const canSubmitAskUser = computed(() =>
   isChatEligible.value &&
@@ -1123,6 +1140,8 @@ async function openSession(sessionId: string) {
   clearChatError();
   clearPendingAskUser();
   const result = await chat.getSessionMessages(sessionId);
+  workspaceChanges.value = (await chat.listWorkspaceChanges(sessionId)).changes;
+  selectedWorkspaceChangeId.value = workspaceChanges.value[0]?.change_id ?? null;
   const firstRecord = result.messages[0];
   if (firstRecord?.agent_id && services.value.some((a) => a.config_id === firstRecord.agent_id)) {
     selectedServiceId.value = firstRecord.agent_id;
@@ -1142,6 +1161,71 @@ async function openSession(sessionId: string) {
   applyHistory(result.messages);
   messageBranches.value = result.branches;
   editingMessage.value = null;
+}
+
+function applyWorkspaceChange(change: WorkspaceChange) {
+  const index = workspaceChanges.value.findIndex((item) => item.change_id === change.change_id);
+  if (index >= 0) {
+    workspaceChanges.value[index] = change;
+  } else if (change.status === "pending") {
+    workspaceChanges.value.push(change);
+  }
+  if (!selectedWorkspaceChangeId.value) {
+    selectedWorkspaceChangeId.value = change.change_id;
+  }
+}
+
+function openWorkspaceChange(change: WorkspaceChange) {
+  selectedWorkspaceChangeId.value = change.change_id;
+  workspaceChangeDialogOpen.value = true;
+  workspaceChangeError.value = "";
+}
+
+function closeWorkspaceChange() {
+  workspaceChangeDialogOpen.value = false;
+}
+
+async function acceptWorkspaceChange(change: WorkspaceChange) {
+  if (!activeSessionId.value) return;
+  try {
+    await chat.acceptWorkspaceChange(activeSessionId.value, change.change_id);
+    workspaceChanges.value = workspaceChanges.value.filter((item) => item.change_id !== change.change_id);
+    if (selectedWorkspaceChangeId.value === change.change_id) {
+      selectedWorkspaceChangeId.value = workspaceChanges.value[0]?.change_id ?? null;
+    }
+    workspaceChangeDialogOpen.value = false;
+  } catch (error) {
+    workspaceChangeError.value = `接受失败: ${(error as Error).message}`;
+  }
+}
+
+async function cancelWorkspaceChange(change: WorkspaceChange) {
+  if (!activeSessionId.value) return;
+  try {
+    await chat.cancelWorkspaceChange(activeSessionId.value, change.change_id);
+    workspaceChanges.value = workspaceChanges.value.filter((item) => item.change_id !== change.change_id);
+    if (selectedWorkspaceChangeId.value === change.change_id) {
+      selectedWorkspaceChangeId.value = workspaceChanges.value[0]?.change_id ?? null;
+    }
+    workspaceChangeDialogOpen.value = false;
+  } catch (error) {
+    workspaceChangeError.value = `撤销失败: ${(error as Error).message}`;
+  }
+}
+
+async function acceptWorkspaceFile(path: string) {
+  const changes = workspaceChanges.value.filter((item) => item.display_path === path);
+  for (const change of changes) {
+    await acceptWorkspaceChange(change);
+  }
+}
+
+async function cancelWorkspaceFile(path: string) {
+  const changes = workspaceChanges.value.filter((item) => item.display_path === path);
+  for (const change of changes) {
+    await cancelWorkspaceChange(change);
+    if (workspaceChangeError.value) break;
+  }
 }
 
 async function copyMessage(message: ChatMessage): Promise<void> {
@@ -1237,6 +1321,10 @@ function startNewSession() {
   editingMessage.value = null;
   clearChatError();
   clearPendingAskUser();
+  workspaceChanges.value = [];
+  selectedWorkspaceChangeId.value = null;
+  workspaceChangeDialogOpen.value = false;
+  workspaceChangeError.value = "";
 }
 
 function selectModel(id: string) {
@@ -1308,6 +1396,11 @@ function applyStreamEvent(event: ChatStreamEvent, streamState: StreamState) {
       placeholder: event.placeholder ?? undefined,
     };
     askUserAnswer.value = "";
+    return;
+  }
+
+  if (event.type === "workspace_change" && event.change) {
+    applyWorkspaceChange(event.change);
     return;
   }
 
@@ -1699,6 +1792,12 @@ onUnmounted(() => {
     selectedAgentAvatarUrl,
     selectedAgentAvatarFallback,
     pendingAskUser,
+    workspaceChanges,
+    workspaceFileGroups,
+    selectedWorkspaceChange,
+    selectedWorkspaceChangeId,
+    workspaceChangeDialogOpen,
+    workspaceChangeError,
     askUserAnswer,
     canSubmitAskUser,
     messageGroups,
@@ -1739,6 +1838,12 @@ onUnmounted(() => {
     handleImagePreviewKeydown,
     toggleAutoCollapseThinking,
     clearPendingAskUser,
+    openWorkspaceChange,
+    closeWorkspaceChange,
+    acceptWorkspaceChange,
+    cancelWorkspaceChange,
+    acceptWorkspaceFile,
+    cancelWorkspaceFile,
     pruneFailedAssistantPlaceholder,
     applyInferenceFailure,
     reloadSessions,

--- a/webui/src/admin/composables/useChat.ts
+++ b/webui/src/admin/composables/useChat.ts
@@ -1534,7 +1534,7 @@ async function sendMessageWithText(rawInput: string, fromAskUser: boolean, optio
   ];
 
   if (fromAskUser) {
-    askUserAnswer.value = "";
+    clearPendingAskUser();
   } else if (!options.attachments) {
     draftMessage.value = "";
     draftImageAttachments.value = [];

--- a/webui/src/admin/composables/useChat.ts
+++ b/webui/src/admin/composables/useChat.ts
@@ -5,6 +5,8 @@ import {
   chat,
   fileIO,
   system,
+  agentsMd,
+  type AgentsMdFile,
   type ServiceWithRuntime,
   type ChatHistoryRecord,
   type ChatToolCall,
@@ -356,6 +358,14 @@ const selectedService = computed(
 const selectedServiceType = computed(() => selectedService.value?.agent_type?.type ?? "");
 const isChatEligible = computed(() => CHAT_ELIGIBLE_SERVICE_TYPES.has(selectedServiceType.value));
 const isWorkspaceService = computed(() => selectedServiceType.value === "workspace");
+const agentsMdEnabled = computed(() => {
+  const agentType = selectedService.value?.agent_type as Record<string, unknown> | undefined;
+  return agentType?.agents_md_enabled === true;
+});
+const agentsMdAppliedKeys = computed(() => {
+  if (!agentsMdEnabled.value) return new Set<string>();
+  return new Set(agentsMdFiles.value.filter((file) => file.exists).map((file) => file.key));
+});
 const groupedSessions = computed(() => {
   const groups = new Map<string, ChatSessionSummary[]>();
   for (const session of sessions.value) {
@@ -443,6 +453,13 @@ const workspaceChanges = ref<WorkspaceChange[]>([]);
 const selectedWorkspaceChangeId = ref<string | null>(null);
 const workspaceChangeDialogOpen = ref(false);
 const workspaceChangeError = ref("");
+const agentsMdDialogOpen = ref(false);
+const agentsMdLoading = ref(false);
+const agentsMdSaving = ref(false);
+const agentsMdFiles = ref<AgentsMdFile[]>([]);
+const agentsMdError = ref("");
+const agentsMdEditingKey = ref("");
+const agentsMdEditorContent = ref("");
 const selectedWorkspaceChange = computed(() =>
   workspaceChanges.value.find((item) => item.change_id === selectedWorkspaceChangeId.value) ?? workspaceChanges.value[0] ?? null,
 );
@@ -1311,6 +1328,105 @@ async function pickDirectory() {
   }
 }
 
+function agentsMdLocationLabel(key: string): string {
+  switch (key) {
+    case "workspace": return "工作目录";
+    case "executable": return "运行目录";
+    case "home": return "用户目录";
+    default: return key;
+  }
+}
+
+async function refreshAgentsMd() {
+  agentsMdLoading.value = true;
+  agentsMdError.value = "";
+  try {
+    const result = await agentsMd.list(workspacePath.value);
+    agentsMdFiles.value = result.files;
+    if (!agentsMdEditingKey.value) {
+      const existing = result.files.find((file) => file.exists) ?? result.files[0];
+      agentsMdEditingKey.value = existing?.key ?? "";
+      agentsMdEditorContent.value = existing?.content ?? "";
+    } else {
+      const current = result.files.find((file) => file.key === agentsMdEditingKey.value);
+      if (current) agentsMdEditorContent.value = current.content;
+    }
+  } catch (error) {
+    agentsMdError.value = `加载失败: ${error instanceof Error ? error.message : String(error)}`;
+  } finally {
+    agentsMdLoading.value = false;
+  }
+}
+
+async function openAgentsMdDialog() {
+  agentsMdDialogOpen.value = true;
+  agentsMdEditingKey.value = "";
+  agentsMdEditorContent.value = "";
+  await refreshAgentsMd();
+}
+
+function closeAgentsMdDialog() {
+  agentsMdDialogOpen.value = false;
+  agentsMdError.value = "";
+}
+
+function selectAgentsMdFile(file: AgentsMdFile) {
+  agentsMdEditingKey.value = file.key;
+  agentsMdEditorContent.value = file.content;
+  agentsMdError.value = "";
+}
+
+async function createAgentsMd() {
+  const existing = agentsMdFiles.value.find((file) => file.key === "workspace" && file.exists);
+  if (existing) {
+    selectAgentsMdFile(existing);
+    return;
+  }
+  agentsMdSaving.value = true;
+  agentsMdError.value = "";
+  try {
+    const created = await agentsMd.save("workspace", "", workspacePath.value);
+    await refreshAgentsMd();
+    const createdFile = agentsMdFiles.value.find((file) => file.path === created.path);
+    if (createdFile) selectAgentsMdFile(createdFile);
+  } catch (error) {
+    agentsMdError.value = `创建失败: ${error instanceof Error ? error.message : String(error)}`;
+  } finally {
+    agentsMdSaving.value = false;
+  }
+}
+
+async function saveAgentsMd() {
+  if (!agentsMdEditingKey.value) return;
+  agentsMdSaving.value = true;
+  agentsMdError.value = "";
+  try {
+    await agentsMd.save(agentsMdEditingKey.value, agentsMdEditorContent.value, workspacePath.value);
+    await refreshAgentsMd();
+  } catch (error) {
+    agentsMdError.value = `保存失败: ${error instanceof Error ? error.message : String(error)}`;
+  } finally {
+    agentsMdSaving.value = false;
+  }
+}
+
+async function deleteAgentsMd(file: AgentsMdFile) {
+  agentsMdSaving.value = true;
+  agentsMdError.value = "";
+  try {
+    await agentsMd.remove(file.key, workspacePath.value);
+    if (agentsMdEditingKey.value === file.key) {
+      agentsMdEditingKey.value = "";
+      agentsMdEditorContent.value = "";
+    }
+    await refreshAgentsMd();
+  } catch (error) {
+    agentsMdError.value = `删除失败: ${error instanceof Error ? error.message : String(error)}`;
+  } finally {
+    agentsMdSaving.value = false;
+  }
+}
+
 function startNewSession() {
   activeSessionId.value = "";
   emit("update:sessionId", "");
@@ -1325,6 +1441,10 @@ function startNewSession() {
   selectedWorkspaceChangeId.value = null;
   workspaceChangeDialogOpen.value = false;
   workspaceChangeError.value = "";
+  agentsMdDialogOpen.value = false;
+  agentsMdEditingKey.value = "";
+  agentsMdEditorContent.value = "";
+  agentsMdError.value = "";
 }
 
 function selectModel(id: string) {
@@ -1798,6 +1918,23 @@ onUnmounted(() => {
     selectedWorkspaceChangeId,
     workspaceChangeDialogOpen,
     workspaceChangeError,
+    agentsMdDialogOpen,
+    agentsMdLoading,
+    agentsMdSaving,
+    agentsMdFiles,
+    agentsMdError,
+    agentsMdEditingKey,
+    agentsMdEditorContent,
+    agentsMdEnabled,
+    agentsMdAppliedKeys,
+    agentsMdLocationLabel,
+    openAgentsMdDialog,
+    closeAgentsMdDialog,
+    refreshAgentsMd,
+    selectAgentsMdFile,
+    createAgentsMd,
+    saveAgentsMd,
+    deleteAgentsMd,
     askUserAnswer,
     canSubmitAskUser,
     messageGroups,

--- a/webui/src/admin/model.ts
+++ b/webui/src/admin/model.ts
@@ -169,6 +169,7 @@ export interface ServiceFormState {
   http_weaviate_memory_connection_id: string;
   http_elasticsearch_memory_connection_id: string;
   task_db_connection_id: string;
+  agents_md_enabled: boolean;
   tools: ToolFormState[];
   avatar_url: string;
 }
@@ -494,6 +495,7 @@ export function defaultServiceForm(): ServiceFormState {
     http_weaviate_memory_connection_id: "",
     http_elasticsearch_memory_connection_id: "",
     task_db_connection_id: "",
+    agents_md_enabled: false,
     tools: [],
     avatar_url: "",
   };
@@ -1042,6 +1044,7 @@ export function serviceFormFromConfig(
     }
   } else {
     form.llm_ref_id = String(agentType.llm_ref_id ?? "");
+    form.agents_md_enabled = Boolean(agentType.agents_md_enabled ?? false);
     const source = (agentType.default_tools_enabled ?? {}) as Record<
       string,
       unknown
@@ -1235,6 +1238,7 @@ export function buildServicePayload(form: ServiceFormState): {
     agent_type: {
       type: "workspace",
       llm_ref_id: form.llm_ref_id || null,
+      agents_md_enabled: form.agents_md_enabled,
       default_tools_enabled: Object.fromEntries(
         WORKSPACE_DEFAULT_TOOLS.map((tool) => [
           tool.id,

--- a/webui/src/admin/styles/agents-md.scss
+++ b/webui/src/admin/styles/agents-md.scss
@@ -1,0 +1,163 @@
+.agents-md-chip {
+  font-size: 11px;
+  letter-spacing: .3px;
+}
+.agents-md-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(8, 12, 20, .58);
+}
+.agents-md-dialog {
+  width: min(900px, 94vw);
+  height: min(620px, 84vh);
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr);
+  overflow: hidden;
+  border: 1px solid var(--admin-border);
+  border-radius: 14px;
+  background: var(--admin-bg-panel);
+  box-shadow: 0 24px 80px rgba(0,0,0,.28);
+}
+.agents-md-dialog-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px 10px;
+  overflow-y: auto;
+  border-right: 1px solid var(--admin-border);
+}
+.agents-md-dialog-sidebar > strong { display: block; padding: 0 8px; }
+.agents-md-disabled-hint {
+  padding: 6px 8px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--admin-muted);
+  background: var(--admin-bg-soft);
+  border-radius: 7px;
+}
+.agents-md-toolbar { display: flex; gap: 6px; padding: 0 8px; }
+.agents-md-toolbar button {
+  flex: 1;
+  padding: 6px 8px;
+  border: 1px solid var(--admin-border);
+  border-radius: 6px;
+  background: var(--admin-bg-panel);
+  color: var(--admin-ink);
+  cursor: pointer;
+  font-size: 12px;
+}
+.agents-md-toolbar button:disabled { opacity: .5; cursor: not-allowed; }
+.agents-md-create { border-color: var(--admin-accent) !important; color: var(--admin-accent) !important; }
+.agents-md-loading { padding: 4px 8px; color: var(--admin-muted); font-size: 12px; }
+.agents-md-file-row { display: grid; gap: 4px; margin-bottom: 6px; }
+.agents-md-file {
+  display: grid;
+  gap: 4px;
+  padding: 9px 8px;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--admin-ink);
+  cursor: pointer;
+}
+.agents-md-file.active { background: var(--admin-bg-soft); }
+.agents-md-file.applied {
+  border-color: var(--admin-accent);
+  box-shadow: 0 0 0 1px var(--admin-accent);
+}
+.agents-md-file-head { display: flex; align-items: center; justify-content: space-between; gap: 6px; }
+.agents-md-file-head strong { font-size: 13px; }
+.agents-md-status { font-size: 11px; color: var(--admin-muted); white-space: nowrap; }
+.agents-md-status--exists { color: var(--admin-accent); }
+.agents-md-file-path {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: monospace;
+  font-size: 11px;
+  color: var(--admin-muted);
+}
+.agents-md-file-actions { display: flex; gap: 4px; padding: 0 8px; }
+.agents-md-file-actions button {
+  flex: 1;
+  border: 1px solid var(--admin-border);
+  border-radius: 5px;
+  padding: 3px 8px;
+  font-size: 11px;
+  cursor: pointer;
+  background: var(--admin-bg-panel);
+  color: var(--admin-ink);
+}
+.agents-md-file-actions button:disabled { opacity: .5; cursor: not-allowed; }
+.agents-md-delete { border-color: var(--admin-bad) !important; color: var(--admin-bad) !important; }
+.agents-md-error { padding: 6px 8px; color: var(--admin-bad); font-size: 12px; }
+.agents-md-dialog-main { min-width: 0; min-height: 0; display: flex; flex-direction: column; }
+.agents-md-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--admin-border);
+}
+.agents-md-dialog-header button { border: 0; background: transparent; color: var(--admin-muted); cursor: pointer; }
+.agents-md-editor-wrap {
+  flex: 1;
+  min-height: 0;
+  padding: 16px 18px;
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  gap: 0;
+  overflow: hidden;
+}
+.agents-md-line-numbers {
+  min-height: 0;
+  padding: 12px 8px;
+  border: 1px solid var(--admin-border);
+  border-right: 0;
+  border-radius: 8px 0 0 8px;
+  background: var(--admin-bg-panel);
+  color: var(--admin-muted);
+  font: 13px/1.6 ui-monospace, SFMono-Regular, Consolas, monospace;
+  text-align: right;
+  overflow: hidden;
+  -webkit-user-select: none;
+  user-select: none;
+}
+.agents-md-line-number {
+  min-height: 1.6em;
+}
+.agents-md-editor {
+  min-height: 0;
+  min-width: 0;
+  resize: none;
+  border: 1px solid var(--admin-border);
+  border-radius: 0 8px 8px 0;
+  padding: 12px;
+  background: var(--admin-bg-soft);
+  color: var(--admin-ink);
+  font: 13px/1.6 ui-monospace, SFMono-Regular, Consolas, monospace;
+  outline: none;
+  overflow: auto;
+  white-space: pre;
+}
+.agents-md-editor:focus { border-color: var(--admin-accent); }
+.agents-md-dialog-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 18px;
+  border-top: 1px solid var(--admin-border);
+}
+.agents-md-dialog-actions button { padding: 7px 14px; border-radius: 6px; cursor: pointer; border: 1px solid var(--admin-border); }
+.agents-md-dialog-actions button:disabled { opacity: .5; cursor: not-allowed; }
+.agents-md-save { background: var(--admin-accent); border-color: var(--admin-accent); color: #fff; }
+.agents-md-cancel { background: var(--admin-bg-panel); color: var(--admin-ink); }
+@media (max-width: 640px) {
+  .agents-md-dialog { grid-template-columns: 1fr; grid-template-rows: 190px minmax(0, 1fr); }
+  .agents-md-dialog-sidebar { border-right: 0; border-bottom: 1px solid var(--admin-border); }
+}

--- a/webui/src/admin/styles/workspace-change.scss
+++ b/webui/src/admin/styles/workspace-change.scss
@@ -1,0 +1,83 @@
+.workspace-change-panel {
+  margin-bottom: 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--admin-border);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--admin-accent-soft) 34%, var(--admin-bg-panel) 66%);
+  max-height: 132px;
+  overflow: hidden;
+}
+
+.workspace-change-panel-header,
+.workspace-change-row,
+.workspace-change-dialog-header,
+.workspace-change-dialog-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.workspace-change-panel-header {
+  justify-content: space-between;
+  font-size: 12px;
+  color: var(--admin-muted);
+  margin-bottom: 5px;
+}
+
+.workspace-change-panel-header strong { color: var(--admin-ink); font-size: 13px; }
+.workspace-change-list { overflow-y: auto; max-height: 91px; display: grid; gap: 3px; }
+.workspace-change-row { min-width: 0; }
+.workspace-change-summary {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  flex: 1;
+  border: 0;
+  background: transparent;
+  color: var(--admin-ink);
+  text-align: left;
+  cursor: pointer;
+  padding: 4px 0;
+}
+.workspace-change-operation { color: var(--admin-accent); font-size: 11px; text-transform: uppercase; }
+.workspace-change-path { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.workspace-change-lines { flex-shrink: 0; color: var(--admin-muted); font-size: 11px; }
+.workspace-change-accept,
+.workspace-change-cancel {
+  border: 1px solid var(--admin-border);
+  border-radius: 5px;
+  padding: 3px 8px;
+  font-size: 11px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.workspace-change-accept { background: #2e9b59; border-color: #2e9b59; color: #fff; }
+.workspace-change-cancel { background: var(--admin-bg-panel); color: var(--admin-ink); }
+.workspace-change-overlay { position: fixed; inset: 0; z-index: 1000; display: grid; place-items: center; padding: 24px; background: rgba(8, 12, 20, .58); }
+.workspace-change-dialog { width: min(900px, 94vw); height: min(620px, 84vh); display: grid; grid-template-columns: 240px minmax(0, 1fr); overflow: hidden; border: 1px solid var(--admin-border); border-radius: 14px; background: var(--admin-bg-panel); box-shadow: 0 24px 80px rgba(0,0,0,.28); }
+.workspace-change-dialog-sidebar { padding: 16px 10px; overflow-y: auto; border-right: 1px solid var(--admin-border); }
+.workspace-change-dialog-sidebar > strong { display: block; padding: 0 8px 12px; }
+.workspace-change-file { width: 100%; display: grid; gap: 3px; padding: 9px 8px; border: 0; border-radius: 7px; background: transparent; color: var(--admin-ink); text-align: left; cursor: pointer; }
+.workspace-change-file-row { display: grid; gap: 4px; margin-bottom: 6px; }
+.workspace-change-file-actions { display: flex; gap: 4px; padding: 0 8px; }
+.workspace-change-file-actions button { flex: 1; }
+.workspace-change-file span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.workspace-change-file small { color: var(--admin-muted); }
+.workspace-change-file.active, .workspace-change-file:hover { background: var(--admin-bg-soft); }
+.workspace-change-dialog-main { min-width: 0; display: flex; flex-direction: column; }
+.workspace-change-dialog-header { justify-content: space-between; padding: 16px 18px; border-bottom: 1px solid var(--admin-border); }
+.workspace-change-dialog-header button { border: 0; background: transparent; color: var(--admin-muted); cursor: pointer; }
+.workspace-change-detail { flex: 1; overflow-y: auto; padding: 20px; }
+.workspace-change-detail-meta { display: flex; flex-wrap: wrap; gap: 14px; color: var(--admin-muted); font-size: 13px; }
+.workspace-change-paths { margin-top: 20px; padding: 12px; border-radius: 8px; background: var(--admin-bg-soft); font-family: monospace; font-size: 12px; overflow-x: auto; }
+.workspace-change-diff { margin-top: 14px; max-height: 300px; overflow: auto; border: 1px solid var(--admin-border); border-radius: 8px; font: 12px/1.55 monospace; }
+.workspace-change-diff-line { padding: 2px 10px; white-space: pre-wrap; }
+.workspace-change-diff-line span { display: inline-block; width: 16px; font-weight: 700; }
+.workspace-change-diff-line--added { color: #237a43; background: color-mix(in srgb, #3cad68 12%, transparent); }
+.workspace-change-diff-line--removed { color: #b03b46; background: color-mix(in srgb, #e06b76 12%, transparent); }
+.workspace-change-note { color: var(--admin-muted); line-height: 1.6; }
+.workspace-change-error { color: var(--admin-bad); }
+.workspace-change-dialog-actions { justify-content: flex-end; padding: 12px 18px; border-top: 1px solid var(--admin-border); }
+.workspace-change-dialog-actions button { padding: 7px 14px; }
+@media (max-width: 640px) { .workspace-change-dialog { grid-template-columns: 1fr; grid-template-rows: 150px minmax(0, 1fr); } .workspace-change-dialog-sidebar { border-right: 0; border-bottom: 1px solid var(--admin-border); } }

--- a/webui/src/admin/view/AgentService.vue
+++ b/webui/src/admin/view/AgentService.vue
@@ -48,6 +48,10 @@
                   <t-option v-for="item in chatModels" :key="item.config_id" :value="item.config_id" :label="item.name" />
                 </t-select>
               </t-form-item>
+              <t-form-item v-if="form.type === 'workspace'" label="AGENTS.md">
+                <t-checkbox v-model="form.agents_md_enabled">关注 AGENTS.md</t-checkbox>
+                <div class="agent-service-form-hint">让Agent关注 AGENTS.md</div>
+              </t-form-item>
             </div>
           </t-card>
 
@@ -472,6 +476,10 @@
               <t-select v-model="form.llm_ref_id" placeholder="请选择">
                 <t-option v-for="item in chatModels" :key="item.config_id" :value="item.config_id" :label="item.name" />
               </t-select>
+            </t-form-item>
+            <t-form-item v-if="form.type === 'workspace'" label="AGENTS.md">
+              <t-checkbox v-model="form.agents_md_enabled">关注 AGENTS.md</t-checkbox>
+              <div class="agent-service-form-hint">让Agent 关注 AGENTS.md</div>
             </t-form-item>
           </div>
         </t-card>

--- a/webui/src/admin/view/Chat.vue
+++ b/webui/src/admin/view/Chat.vue
@@ -616,6 +616,23 @@
                 <div class="chat-not-supported-desc">请在 QQ 群或 HTTP Stream 端点中使用该 Agent。</div>
               </div>
               <template v-else>
+                <div v-if="workspaceChanges.length" class="workspace-change-panel">
+                  <div class="workspace-change-panel-header">
+                    <strong>文件更改</strong>
+                    <span>{{ workspaceChanges.length }} 处待处理</span>
+                  </div>
+                  <div class="workspace-change-list">
+                    <div v-for="change in workspaceChanges" :key="change.change_id" class="workspace-change-row">
+                      <button class="workspace-change-summary" @click="openWorkspaceChange(change)">
+                        <span class="workspace-change-operation">{{ change.operation }}</span>
+                        <span class="workspace-change-path" :title="change.paths.join(' → ')">{{ change.display_path }}</span>
+                        <span class="workspace-change-lines">+{{ change.added_lines }} / -{{ change.removed_lines }}</span>
+                      </button>
+                      <button class="workspace-change-accept" @click="acceptWorkspaceChange(change)">Accept</button>
+                      <button class="workspace-change-cancel" @click="cancelWorkspaceChange(change)">Cancel</button>
+                    </div>
+                  </div>
+                </div>
                 <div v-if="pendingAskUser" class="ask-user-panel">
                   <div class="ask-user-question">{{ pendingAskUser.question }}</div>
                   <div v-if="pendingAskUser.details" class="ask-user-details">
@@ -865,6 +882,62 @@
         </div>
       </section>
     </div>
+
+    <Teleport to="body">
+      <div v-if="workspaceChangeDialogOpen" class="workspace-change-overlay" @click.self="closeWorkspaceChange">
+        <div class="workspace-change-dialog" role="dialog" aria-modal="true" aria-label="文件更改">
+          <aside class="workspace-change-dialog-sidebar">
+            <strong>文件更改</strong>
+            <div v-for="group in workspaceFileGroups" :key="group.path" class="workspace-change-file-row">
+              <button
+                class="workspace-change-file"
+                :class="{ active: selectedWorkspaceChange?.display_path === group.path }"
+                @click="openWorkspaceChange(group.changes[0])"
+              >
+                <span>{{ group.path }}</span>
+                <small>{{ group.changes.length }} 处更改</small>
+              </button>
+              <div class="workspace-change-file-actions">
+                <button class="workspace-change-accept" @click="acceptWorkspaceFile(group.path)">Accept</button>
+                <button class="workspace-change-cancel" @click="cancelWorkspaceFile(group.path)">Cancel</button>
+              </div>
+            </div>
+          </aside>
+          <section class="workspace-change-dialog-main">
+            <header class="workspace-change-dialog-header">
+              <strong>{{ selectedWorkspaceChange?.display_path || "文件更改" }}</strong>
+              <button aria-label="关闭文件更改" @click="closeWorkspaceChange"><CloseIcon /></button>
+            </header>
+            <div v-if="selectedWorkspaceChange" class="workspace-change-detail">
+              <div class="workspace-change-detail-meta">
+                <span>操作：{{ selectedWorkspaceChange.operation }}</span>
+                <span>合并：{{ selectedWorkspaceChange.merged_count }} 次</span>
+                <span>行数：+{{ selectedWorkspaceChange.added_lines }} / -{{ selectedWorkspaceChange.removed_lines }}</span>
+              </div>
+              <div class="workspace-change-paths">
+                <div v-for="path in selectedWorkspaceChange.paths" :key="path">{{ path }}</div>
+              </div>
+              <div v-if="selectedWorkspaceChange.diff.length" class="workspace-change-diff">
+                <div
+                  v-for="(line, index) in selectedWorkspaceChange.diff"
+                  :key="`${line.kind}-${index}`"
+                  class="workspace-change-diff-line"
+                  :class="`workspace-change-diff-line--${line.kind}`"
+                >
+                  <span>{{ line.kind === "added" ? "+" : "−" }}</span>{{ line.line }}
+                </div>
+              </div>
+              <p class="workspace-change-note">文件已写入磁盘。Accept 只确认并移除记录，Cancel 会在文件未被外部修改时恢复。</p>
+              <p v-if="workspaceChangeError" class="workspace-change-error">{{ workspaceChangeError }}</p>
+            </div>
+            <footer v-if="selectedWorkspaceChange" class="workspace-change-dialog-actions">
+              <button class="workspace-change-accept" @click="acceptWorkspaceChange(selectedWorkspaceChange)">Accept</button>
+              <button class="workspace-change-cancel" @click="cancelWorkspaceChange(selectedWorkspaceChange)">Cancel</button>
+            </footer>
+          </section>
+        </div>
+      </div>
+    </Teleport>
 
     <Teleport to="body">
       <div v-if="chatErrorDialogMessage" class="chat-error-dialog-overlay" @click.self="closeChatErrorDialog">
@@ -1193,6 +1266,11 @@ const {
   selectedAgentAvatarUrl,
   selectedAgentAvatarFallback,
   pendingAskUser,
+  workspaceChanges,
+  workspaceFileGroups,
+  selectedWorkspaceChange,
+  workspaceChangeDialogOpen,
+  workspaceChangeError,
   askUserAnswer,
   canSubmitAskUser,
   messageGroups,
@@ -1236,6 +1314,12 @@ const {
   handleImagePreviewKeydown,
   toggleAutoCollapseThinking,
   clearPendingAskUser,
+  openWorkspaceChange,
+  closeWorkspaceChange,
+  acceptWorkspaceChange,
+  cancelWorkspaceChange,
+  acceptWorkspaceFile,
+  cancelWorkspaceFile,
   pruneFailedAssistantPlaceholder,
   applyInferenceFailure,
   reloadSessions,

--- a/webui/src/admin/view/Chat.vue
+++ b/webui/src/admin/view/Chat.vue
@@ -832,6 +832,15 @@
                         </div>
                       </div>
 
+                      <button
+                        v-if="isWorkspaceService"
+                        class="model-chip agents-md-chip"
+                        title="管理 AGENTS.md"
+                        @click.stop="openAgentsMdDialog"
+                      >
+                        AGENTS.md
+                      </button>
+
                       <div class="model-settings" :class="{ open: openPicker === 'settings' }">
                         <button
                           class="model-chip icon-only"
@@ -933,6 +942,67 @@
             <footer v-if="selectedWorkspaceChange" class="workspace-change-dialog-actions">
               <button class="workspace-change-accept" @click="acceptWorkspaceChange(selectedWorkspaceChange)">Accept</button>
               <button class="workspace-change-cancel" @click="cancelWorkspaceChange(selectedWorkspaceChange)">Cancel</button>
+            </footer>
+          </section>
+        </div>
+      </div>
+    </Teleport>
+
+    <Teleport to="body">
+      <div v-if="agentsMdDialogOpen" class="agents-md-overlay" @click.self="closeAgentsMdDialog">
+        <div class="agents-md-dialog" role="dialog" aria-modal="true" aria-label="AGENTS.md 管理">
+          <aside class="agents-md-dialog-sidebar">
+            <strong>AGENTS.md</strong>
+            <div v-if="!agentsMdEnabled" class="agents-md-disabled-hint">当前未开启 AGENTS.md 读取，可在 Service 配置中开启后按优先级应用。</div>
+            <div v-if="!workspacePath" class="agents-md-disabled-hint">未选择工作目录，将使用当前运行目录检测 AGENTS.md。</div>
+            <div class="agents-md-toolbar">
+              <button class="agents-md-create" :disabled="agentsMdSaving" @click="createAgentsMd">创建 AGENTS.md</button>
+              <button class="agents-md-refresh" :disabled="agentsMdLoading" @click="refreshAgentsMd">刷新</button>
+            </div>
+            <div v-if="agentsMdLoading" class="agents-md-loading">加载中…</div>
+            <div v-for="file in agentsMdFiles" :key="file.key" class="agents-md-file-row">
+              <div
+                class="agents-md-file"
+                :class="{ active: agentsMdEditingKey === file.key, applied: agentsMdAppliedKeys.has(file.key) }"
+              >
+                <div class="agents-md-file-head">
+                  <strong>{{ agentsMdLocationLabel(file.key) }}</strong>
+                  <span v-if="file.exists" class="agents-md-status agents-md-status--exists">
+                    {{ agentsMdAppliedKeys.has(file.key) ? "已应用" : "存在" }}
+                  </span>
+                  <span v-else class="agents-md-status">未创建</span>
+                </div>
+                <span class="agents-md-file-path" :title="file.path">{{ file.path }}</span>
+              </div>
+              <div class="agents-md-file-actions">
+                <button v-if="file.exists" class="agents-md-edit" :disabled="agentsMdSaving" @click="selectAgentsMdFile(file)">编辑</button>
+                <button v-if="file.exists" class="agents-md-delete" :disabled="agentsMdSaving" @click="deleteAgentsMd(file)">删除</button>
+              </div>
+            </div>
+            <div v-if="agentsMdError" class="agents-md-error">{{ agentsMdError }}</div>
+          </aside>
+          <section class="agents-md-dialog-main">
+            <header class="agents-md-dialog-header">
+              <strong>{{ agentsMdEditingKey ? `编辑 ${agentsMdLocationLabel(agentsMdEditingKey)} AGENTS.md` : "AGENTS.md 内容" }}</strong>
+              <button aria-label="关闭 AGENTS.md 管理" @click="closeAgentsMdDialog"><CloseIcon /></button>
+            </header>
+            <div class="agents-md-editor-wrap">
+              <div ref="agentsMdLineNumbersRef" class="agents-md-line-numbers">
+                <div v-for="n in agentsMdLineCount" :key="n" class="agents-md-line-number">{{ n }}</div>
+              </div>
+              <textarea
+                ref="agentsMdEditorRef"
+                v-model="agentsMdEditorContent"
+                class="agents-md-editor"
+                spellcheck="false"
+                wrap="off"
+                placeholder="输入 AGENTS.md 内容…"
+                @scroll="syncAgentsMdScroll"
+              ></textarea>
+            </div>
+            <footer class="agents-md-dialog-actions">
+              <button class="agents-md-save" :disabled="agentsMdSaving || !agentsMdEditingKey" @click="saveAgentsMd">保存</button>
+              <button class="agents-md-cancel" :disabled="agentsMdSaving" @click="closeAgentsMdDialog">取消</button>
             </footer>
           </section>
         </div>
@@ -1195,7 +1265,7 @@ import {
   ChatIcon,
 } from "tdesign-icons-vue-next";
 
-import { ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 
 import { useChat } from "../composables/useChat";
 import ToolCallBadge from "./ToolCallBadge.vue";
@@ -1345,8 +1415,44 @@ const {
   agentAvatarUrl,
   agentInitial,
   getAvatarDisplayUrl,
+  agentsMdDialogOpen,
+  agentsMdLoading,
+  agentsMdSaving,
+  agentsMdFiles,
+  agentsMdError,
+  agentsMdEditingKey,
+  agentsMdEditorContent,
+  agentsMdEnabled,
+  agentsMdAppliedKeys,
+  agentsMdLocationLabel,
+  openAgentsMdDialog,
+  closeAgentsMdDialog,
+  refreshAgentsMd,
+  selectAgentsMdFile,
+  createAgentsMd,
+  saveAgentsMd,
+  deleteAgentsMd,
   CHAT_ELIGIBLE_SERVICE_TYPES,
 } = useChat(props, emit);
+
+const agentsMdEditorRef = ref<HTMLTextAreaElement | null>(null);
+const agentsMdLineNumbersRef = ref<HTMLElement | null>(null);
+
+const agentsMdLineCount = computed(() => {
+  const content = agentsMdEditorContent.value;
+  if (!content) {
+    return 1;
+  }
+  return content.split("\n").length;
+});
+
+function syncAgentsMdScroll() {
+  const editor = agentsMdEditorRef.value;
+  const gutter = agentsMdLineNumbersRef.value;
+  if (editor && gutter) {
+    gutter.scrollTop = editor.scrollTop;
+  }
+}
 </script>
 
 <style scoped lang="scss">

--- a/webui/src/api/client.ts
+++ b/webui/src/api/client.ts
@@ -494,6 +494,14 @@ export interface WorkspaceChange {
   diff: WorkspaceDiffLine[];
 }
 
+export type AgentsMdLocationKey = "workspace" | "executable" | "home";
+export interface AgentsMdFile {
+  key: AgentsMdLocationKey;
+  path: string;
+  exists: boolean;
+  content: string;
+}
+
 export interface ChatToolCall {
   id: string;
   type_name: string;
@@ -1077,6 +1085,21 @@ export const chat = {
 
   cancelWorkspaceChange(sessionId: string, changeId: string): Promise<{ change: WorkspaceChange }> {
     return request("POST", `/chat/sessions/${encodeURIComponent(sessionId)}/changes/${encodeURIComponent(changeId)}/cancel`);
+  },
+};
+
+export const agentsMd = {
+  list(workspacePath: string): Promise<{ files: AgentsMdFile[] }> {
+    const qs = buildQueryString({ workspace_path: workspacePath });
+    return request("GET", `/agents-md${qs ? `?${qs}` : ""}`);
+  },
+  save(key: string, content: string, workspacePath: string): Promise<{ ok: boolean; path: string }> {
+    const qs = buildQueryString({ workspace_path: workspacePath });
+    return request("POST", `/agents-md${qs ? `?${qs}` : ""}`, { key, content });
+  },
+  remove(key: string, workspacePath: string): Promise<{ ok: boolean; path: string }> {
+    const qs = buildQueryString({ key, workspace_path: workspacePath });
+    return request("DELETE", `/agents-md${qs ? `?${qs}` : ""}`);
   },
 };
 

--- a/webui/src/api/client.ts
+++ b/webui/src/api/client.ts
@@ -454,7 +454,7 @@ export interface NotificationCard {
 }
 
 export interface ChatStreamEvent {
-  type: "start" | "delta" | "thinking_delta" | "done" | "error" | "tool_call_start" | "tool_call_output" | "tool_call_result" | "ask_user";
+  type: "start" | "delta" | "thinking_delta" | "done" | "error" | "tool_call_start" | "tool_call_output" | "tool_call_result" | "workspace_change" | "ask_user";
   session_id?: string;
   message_id?: string;
   index?: number;
@@ -470,6 +470,28 @@ export interface ChatStreamEvent {
   question?: string;
   details?: string;
   placeholder?: string;
+  change?: WorkspaceChange;
+}
+
+export type WorkspaceChangeOperation = "create" | "edit" | "delete" | "copy" | "move";
+export type WorkspaceChangeStatus = "pending" | "accepted" | "canceled";
+export interface WorkspaceDiffLine {
+  kind: "added" | "removed";
+  line: string;
+}
+export interface WorkspaceChange {
+  change_id: string;
+  session_id: string;
+  operation: WorkspaceChangeOperation;
+  paths: string[];
+  display_path: string;
+  added_lines: number;
+  removed_lines: number;
+  before_fingerprint: string;
+  after_fingerprint: string;
+  status: WorkspaceChangeStatus;
+  merged_count: number;
+  diff: WorkspaceDiffLine[];
 }
 
 export interface ChatToolCall {
@@ -1043,6 +1065,18 @@ export const chat = {
 
   deleteSession(sessionId: string): Promise<{ ok: boolean }> {
     return request("DELETE", `/chat/sessions/${sessionId}`);
+  },
+
+  listWorkspaceChanges(sessionId: string): Promise<{ changes: WorkspaceChange[] }> {
+    return request("GET", `/chat/sessions/${encodeURIComponent(sessionId)}/changes`);
+  },
+
+  acceptWorkspaceChange(sessionId: string, changeId: string): Promise<{ change: WorkspaceChange }> {
+    return request("POST", `/chat/sessions/${encodeURIComponent(sessionId)}/changes/${encodeURIComponent(changeId)}/accept`);
+  },
+
+  cancelWorkspaceChange(sessionId: string, changeId: string): Promise<{ change: WorkspaceChange }> {
+    return request("POST", `/chat/sessions/${encodeURIComponent(sessionId)}/changes/${encodeURIComponent(changeId)}/cancel`);
   },
 };
 

--- a/zihuan_service/Cargo.toml
+++ b/zihuan_service/Cargo.toml
@@ -27,3 +27,8 @@ reqwest = { version = "0.12.25", features = ["blocking", "json", "stream"] }
 rand = "0.8"
 regex = "1"
 
+[dev-dependencies]
+zihuan_core = { path = "../zihuan_core" }
+model_inference = { path = "../model_inference" }
+uuid = { version = "1", features = ["v4"] }
+

--- a/zihuan_service/src/agent/workspace_agent_service.rs
+++ b/zihuan_service/src/agent/workspace_agent_service.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use model_inference::system_config::{AgentConfig, WorkspaceAgentServiceConfig};
@@ -18,20 +18,103 @@ use super::tools::{
 };
 use zihuan_core::error::Result;
 
+// Prompt engineering
+
+
+fn workspace_context_prompt(service_name: &str, workspace_path: &str, capabilities: &str) -> String {
+    format!(
+        "You are {service_name}, an assistant operating in the workspace directory: {workspace_path}\n\
+         {capabilities}"
+    )
+}
+
+fn build_tool_capabilities(enabled: &std::collections::HashMap<String, bool>) -> String {
+    let mut capabilities = Vec::new();
+    if is_enabled(enabled, DEFAULT_TOOL_READ_FILE) {
+        capabilities.push("read files (read_file can read binary fragments as base64 when needed)");
+    }
+    if is_enabled(enabled, DEFAULT_TOOL_LIST_DIR) {
+        capabilities.push("list directories");
+    }
+    if is_enabled(enabled, DEFAULT_TOOL_FIND_FILES) {
+        capabilities.push("find paths by name");
+    }
+    if is_enabled(enabled, DEFAULT_TOOL_GREP) || is_enabled(enabled, DEFAULT_TOOL_RG) {
+        capabilities.push("search text");
+    }
+    if is_enabled(enabled, DEFAULT_TOOL_CREATE_FILE) {
+        capabilities.push("create files");
+    }
+    if is_enabled(enabled, DEFAULT_TOOL_EDIT_FILE) {
+        capabilities.push("edit files");
+    }
+    if is_enabled(enabled, DEFAULT_TOOL_DELETE_FILE) {
+        capabilities.push("delete files");
+    }
+    if is_enabled(enabled, DEFAULT_TOOL_COPY_FILE) {
+        capabilities.push("copy files");
+    }
+    if is_enabled(enabled, DEFAULT_TOOL_MOVE_FILE) {
+        capabilities.push("move files");
+    }
+    if is_enabled(enabled, DEFAULT_TOOL_FILE_INFO) {
+        capabilities.push("view metadata");
+    }
+    if is_enabled(enabled, DEFAULT_TOOL_GIT_STATUS) {
+        capabilities.push("view Git status");
+    }
+    if is_enabled(enabled, DEFAULT_TOOL_EXEC_CMD) {
+        capabilities.push("execute commands");
+    }
+    if is_enabled(enabled, DEFAULT_TOOL_ASK_USER) {
+        capabilities.push("ask the user for clarification");
+    }
+    if capabilities.is_empty() {
+        "You have no workspace tools enabled.".to_string()
+    } else {
+        format!("You can {}.", capabilities.join(", "))
+    }
+}
+
+fn agents_md_prompt(references: &str) -> String {
+    format!(
+        "[Mandatory Requirement] Before starting any work, you must use read_file to read each of the following AGENTS.md files one by one, and strictly follow the project rules, coding standards, architecture conventions, and build commands within them. These files are the highest-priority working constraints for this project: their rules must be followed unconditionally, and if they conflict with general rules or default assumptions, AGENTS.md always takes precedence. You must not create, modify, or delete any files until you have finished reading them. AGENTS.md files to read and follow:\n{references}"
+    )
+}
+
+// ===================================
+
 pub struct WorkspaceInferenceToolProvider {
+    service_name: String,
+    agents_md_enabled: bool,
     default_tools_enabled: std::collections::HashMap<String, bool>,
     tool_definitions: Vec<BrainToolDefinition>,
 }
 
 impl InferenceToolProvider for WorkspaceInferenceToolProvider {
     fn augment_messages(&self, messages: &mut Vec<LLMMessage>, context: &InferenceToolContext) {
-        if let Some(ref path) = context.workspace_path {
-            messages.insert(
-                0,
-                LLMMessage::system(format!(
-                    "当前工作目录是: {path}\n你可以在该目录下读取文件、列出目录、按名称查找路径、搜索文本、创建、编辑、删除、复制、移动文件，查看元数据和 Git 状态，以及执行命令。read_file 可在需要时使用 base64 读取二进制片段。"
-                )),
-            );
+        let capabilities = build_tool_capabilities(&self.default_tools_enabled);
+        let mut prompt = context
+            .workspace_path
+            .as_ref()
+            .map(|path| workspace_context_prompt(&self.service_name, path, &capabilities));
+        if self.agents_md_enabled {
+            let agents_paths = discover_agents_md_paths(context.workspace_path.as_deref());
+            if !agents_paths.is_empty() {
+                let references = agents_paths
+                    .iter()
+                    .map(|path| format!("- {}", path.display()))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                let agents_prompt = agents_md_prompt(&references);
+                prompt = Some(match prompt {
+                    Some(prompt) => format!("{prompt}\n{agents_prompt}"),
+                    None => agents_prompt,
+                });
+            }
+        }
+        if let Some(prompt) = prompt {
+            messages.insert(0, LLMMessage::system(prompt));
         }
     }
 
@@ -110,9 +193,93 @@ pub fn load_inference_tool_provider(
     _connections: &[ConnectionConfig],
 ) -> Result<Arc<dyn InferenceToolProvider>> {
     Ok(Arc::new(WorkspaceInferenceToolProvider {
+        service_name: agent.name.clone(),
+        agents_md_enabled: config.agents_md_enabled,
         default_tools_enabled: config.default_tools_enabled.clone(),
         tool_definitions: build_enabled_tool_definitions(&agent.tools)?,
     }))
+}
+
+/// Location of an `AGENTS.md` candidate, listed in discovery priority order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentsMdLocation {
+    Workspace,
+    Executable,
+    Home,
+}
+
+impl AgentsMdLocation {
+    /// Stable key used by the management API and the frontend.
+    pub fn key(self) -> &'static str {
+        match self {
+            AgentsMdLocation::Workspace => "workspace",
+            AgentsMdLocation::Executable => "executable",
+            AgentsMdLocation::Home => "home",
+        }
+    }
+}
+
+/// One `AGENTS.md` candidate exposed to the management API.
+#[derive(Debug, Clone)]
+pub struct AgentsMdCandidate {
+    pub location: AgentsMdLocation,
+    pub path: PathBuf,
+    pub exists: bool,
+}
+
+/// Lists the candidate `AGENTS.md` files across the workspace, executable, and user home
+/// directories in priority order. When no workspace path is provided, the current process
+/// directory is used as the workspace fallback, matching the effective workspace resolution
+/// used at inference time. Directories that cannot be resolved are skipped.
+pub fn agents_md_candidates(workspace_path: Option<&str>) -> Vec<AgentsMdCandidate> {
+    let workspace_dir = workspace_path
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+        .or_else(|| std::env::current_dir().ok());
+    let executable_dir = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(Path::to_path_buf));
+    let home_dir = std::env::var_os("USERPROFILE")
+        .or_else(|| std::env::var_os("HOME"))
+        .map(PathBuf::from);
+    let mut candidates = Vec::new();
+    if let Some(directory) = workspace_dir {
+        push_agents_md_candidate(&mut candidates, AgentsMdLocation::Workspace, directory);
+    }
+    if let Some(directory) = executable_dir {
+        push_agents_md_candidate(&mut candidates, AgentsMdLocation::Executable, directory);
+    }
+    if let Some(directory) = home_dir {
+        push_agents_md_candidate(&mut candidates, AgentsMdLocation::Home, directory);
+    }
+    candidates
+}
+
+fn push_agents_md_candidate(
+    candidates: &mut Vec<AgentsMdCandidate>,
+    location: AgentsMdLocation,
+    directory: PathBuf,
+) {
+    let path = directory.join("AGENTS.md");
+    let exists = path.is_file();
+    candidates.push(AgentsMdCandidate { location, path, exists });
+}
+
+/// Returns the existing `AGENTS.md` paths in priority order, deduplicated by canonical path.
+pub fn discover_agents_md_paths(workspace_path: Option<&str>) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    for candidate in agents_md_candidates(workspace_path) {
+        if !candidate.exists {
+            continue;
+        }
+        let Ok(path) = std::fs::canonicalize(&candidate.path) else {
+            continue;
+        };
+        if !paths.contains(&path) {
+            paths.push(path);
+        }
+    }
+    paths
 }
 
 fn is_enabled(map: &std::collections::HashMap<String, bool>, name: &str) -> bool {

--- a/zihuan_service/tests/agent/agents_md.rs
+++ b/zihuan_service/tests/agent/agents_md.rs
@@ -1,0 +1,250 @@
+//! Integration tests for Workspace Agent AGENTS.md loading.
+//!
+//! These tests verify that `WorkspaceInferenceToolProvider` injects the correct AGENTS.md
+//! references into the system prompt under different file-location and configuration
+//! combinations.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use model_inference::system_config::{AgentConfig, AgentType, WorkspaceAgentServiceConfig};
+use zihuan_core::llm::{LLMMessage, MessageRole};
+use zihuan_service::agent::inference::{InferenceToolContext, InferenceToolProvider};
+use zihuan_service::agent::workspace_agent_service::load_inference_tool_provider;
+
+/// Serialize tests that mutate process-level environment variables.
+static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+/// Temporary directory that creates an `AGENTS.md` file and cleans itself up on drop.
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new() -> Self {
+        let path = std::env::temp_dir().join(format!("zihuan-agents-md-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&path).expect("failed to create temp directory");
+        Self { path }
+    }
+
+    fn agents_md_path(&self) -> PathBuf {
+        self.path.join("AGENTS.md")
+    }
+
+    fn write_agents_md(&self, content: &str) {
+        std::fs::write(self.agents_md_path(), content).expect("failed to write AGENTS.md");
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+/// Build a Workspace inference tool provider with the requested AGENTS.md flag and no tools.
+fn build_provider(agents_md_enabled: bool) -> std::sync::Arc<dyn InferenceToolProvider> {
+    let workspace_config = WorkspaceAgentServiceConfig {
+        llm_ref_id: None,
+        agents_md_enabled,
+        default_tools_enabled: HashMap::new(),
+    };
+    let agent = AgentConfig {
+        id: "test-agent".to_string(),
+        config_id: "test-config".to_string(),
+        name: "Test Agent".to_string(),
+        agent_type: AgentType::Workspace(workspace_config.clone()),
+        enabled: true,
+        auto_start: false,
+        is_default: false,
+        updated_at: String::new(),
+        tools: Vec::new(),
+        avatar_url: None,
+    };
+    load_inference_tool_provider(&agent, &workspace_config, &[])
+        .expect("failed to load inference tool provider")
+}
+
+/// Run augmentation and return the content of the first system message, if any.
+fn augment_and_get_system_prompt(
+    provider: &std::sync::Arc<dyn InferenceToolProvider>,
+    workspace_path: Option<String>,
+) -> Option<String> {
+    let mut messages = vec![LLMMessage::user("hello")];
+    let context = InferenceToolContext {
+        last_user_text: "hello".to_string(),
+        workspace_path,
+    };
+    provider.augment_messages(&mut messages, &context);
+    messages
+        .into_iter()
+        .find(|message| matches!(message.role, MessageRole::System))
+        .and_then(|message| message.content_text().map(ToOwned::to_owned))
+}
+
+/// Purpose: Verify that the system prompt mentions AGENTS.md and the workspace file path
+/// when the feature is enabled and the file exists.
+///
+/// Test Data: A workspace directory containing `AGENTS.md`; provider configured with
+/// `agents_md_enabled = true`.
+///
+/// Test Measure: The injected system message contains the substring "AGENTS.md", the
+/// `read_file` instruction, and a canonical path line matching the workspace AGENTS.md.
+#[test]
+fn agents_md_enabled_workspace_file_references_agents_md() {
+    let workspace = TempDir::new();
+    workspace.write_agents_md("# Project rules");
+    let provider = build_provider(true);
+    let workspace_path = workspace.path.to_string_lossy().to_string();
+
+    let prompt = augment_and_get_system_prompt(&provider, Some(workspace_path))
+        .expect("system prompt should be injected");
+
+    assert!(prompt.contains("AGENTS.md"), "prompt should mention AGENTS.md");
+    assert!(prompt.contains("read_file"), "prompt should instruct the agent to read AGENTS.md");
+    let expected_canonical = std::fs::canonicalize(workspace.agents_md_path())
+        .expect("failed to canonicalize workspace AGENTS.md");
+    assert!(
+        prompt.contains(&format!("- {}", expected_canonical.display())),
+        "prompt should list the workspace AGENTS.md path"
+    );
+}
+
+/// Purpose: Verify that AGENTS.md references are omitted when the feature is disabled,
+/// even if a workspace AGENTS.md file exists.
+///
+/// Test Data: A workspace directory containing `AGENTS.md`; provider configured with
+/// `agents_md_enabled = false`.
+///
+/// Test Measure: The system prompt does not contain "AGENTS.md" or the workspace
+/// AGENTS.md path, while still describing the workspace context.
+#[test]
+fn agents_md_disabled_does_not_reference_agents_md() {
+    let workspace = TempDir::new();
+    workspace.write_agents_md("# Project rules");
+    let provider = build_provider(false);
+    let workspace_path = workspace.path.to_string_lossy().to_string();
+
+    let prompt = augment_and_get_system_prompt(&provider, Some(workspace_path))
+        .expect("workspace context prompt should be injected");
+
+    assert!(!prompt.contains("AGENTS.md"), "prompt should not mention AGENTS.md when disabled");
+    assert!(
+        !prompt.contains(&format!("- {}", workspace.agents_md_path().display())),
+        "prompt should not list the AGENTS.md path when disabled"
+    );
+    assert!(prompt.contains("workspace directory"), "prompt should still describe the workspace");
+}
+
+/// Purpose: Verify that no AGENTS.md reference is injected when the feature is enabled
+/// but no AGENTS.md file exists in any candidate location.
+///
+/// Test Data: A workspace directory without `AGENTS.md`; provider configured with
+/// `agents_md_enabled = true`.
+///
+/// Test Measure: The system prompt does not contain "AGENTS.md".
+#[test]
+fn agents_md_enabled_missing_file_does_not_reference_agents_md() {
+    let workspace = TempDir::new();
+    let provider = build_provider(true);
+    let workspace_path = workspace.path.to_string_lossy().to_string();
+
+    let prompt = augment_and_get_system_prompt(&provider, Some(workspace_path))
+        .expect("workspace context prompt should be injected");
+
+    assert!(!prompt.contains("AGENTS.md"), "prompt should not mention AGENTS.md when file is absent");
+}
+
+/// Purpose: Verify that a home-directory AGENTS.md is referenced when no workspace file
+/// exists and the feature is enabled.
+///
+/// Test Data: A temporary home directory containing `AGENTS.md`; the `HOME` and
+/// `USERPROFILE` environment variables are redirected to that directory.
+///
+/// Test Measure: The system prompt contains "AGENTS.md" and the canonical home-directory
+/// AGENTS.md path.
+#[test]
+fn agents_md_enabled_home_file_references_agents_md() {
+    let home = TempDir::new();
+    home.write_agents_md("# Home-level rules");
+    let workspace = TempDir::new();
+    let provider = build_provider(true);
+
+    let result = with_home_dir(&home.path, || {
+        augment_and_get_system_prompt(&provider, Some(workspace.path.to_string_lossy().to_string()))
+    });
+
+    let prompt = result.expect("system prompt should be injected");
+    assert!(prompt.contains("AGENTS.md"), "prompt should mention AGENTS.md from home dir");
+    let expected_canonical = std::fs::canonicalize(home.agents_md_path())
+        .expect("failed to canonicalize home AGENTS.md");
+    assert!(
+        prompt.contains(&format!("- {}", expected_canonical.display())),
+        "prompt should list the home AGENTS.md path"
+    );
+}
+
+/// Purpose: Verify that AGENTS.md files from multiple locations are listed in priority
+/// order: workspace first, then home.
+///
+/// Test Data: A workspace directory containing `AGENTS.md` and a temporary home directory
+/// containing `AGENTS.md`; `HOME`/`USERPROFILE` redirected to the temporary home.
+///
+/// Test Measure: The system prompt contains both AGENTS.md paths, and the workspace path
+/// appears before the home path.
+#[test]
+fn agents_md_enabled_multiple_files_lists_in_priority_order() {
+    let workspace = TempDir::new();
+    workspace.write_agents_md("# Workspace rules");
+    let home = TempDir::new();
+    home.write_agents_md("# Home rules");
+    let provider = build_provider(true);
+    let workspace_path = workspace.path.to_string_lossy().to_string();
+
+    let result = with_home_dir(&home.path, || {
+        augment_and_get_system_prompt(&provider, Some(workspace_path.clone()))
+    });
+
+    let prompt = result.expect("system prompt should be injected");
+    let workspace_canonical = std::fs::canonicalize(workspace.agents_md_path())
+        .expect("failed to canonicalize workspace AGENTS.md");
+    let home_canonical = std::fs::canonicalize(home.agents_md_path())
+        .expect("failed to canonicalize home AGENTS.md");
+    let workspace_line = format!("- {}", workspace_canonical.display());
+    let home_line = format!("- {}", home_canonical.display());
+
+    assert!(prompt.contains(&workspace_line), "prompt should list workspace AGENTS.md");
+    assert!(prompt.contains(&home_line), "prompt should list home AGENTS.md");
+    assert!(
+        prompt.find(&workspace_line).expect("workspace line missing") <
+            prompt.find(&home_line).expect("home line missing"),
+        "workspace AGENTS.md should appear before home AGENTS.md"
+    );
+}
+
+/// Run `action` with `HOME` and `USERPROFILE` temporarily redirected to `home_dir`, then
+/// restore the previous values.
+fn with_home_dir<F, R>(home_dir: &std::path::Path, action: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    let _guard = ENV_MUTEX.lock().expect("env mutex poisoned");
+    let previous_home = std::env::var_os("HOME");
+    let previous_userprofile = std::env::var_os("USERPROFILE");
+    std::env::set_var("HOME", home_dir);
+    std::env::set_var("USERPROFILE", home_dir);
+
+    let result = action();
+
+    match previous_home {
+        Some(value) => std::env::set_var("HOME", value),
+        None => std::env::remove_var("HOME"),
+    }
+    match previous_userprofile {
+        Some(value) => std::env::set_var("USERPROFILE", value),
+        None => std::env::remove_var("USERPROFILE"),
+    }
+
+    result
+}

--- a/zihuan_service/tests/agent/main.rs
+++ b/zihuan_service/tests/agent/main.rs
@@ -1,0 +1,1 @@
+mod agents_md;


### PR DESCRIPTION
Implements the change-review layer for Workspace Agent file operations. The underlying tools still write to disk immediately; this module records what happened after the write so the dashboard can present a reviewable change without delaying the agent loop.

--- 
1. `SseBrainObserver::on_tool_start` identifies a mutating workspace tool and calls
 [`WorkspaceChangeRecorder::start`]. The recorder resolves every affected path and captures  its complete before-snapshot.
2. The workspace tool executes normally and writes to disk.
3. `SseBrainObserver::on_tool_finish` passes the tool result to [`WorkspaceChangeRecorder::finish`]. Failed tool results and no-op writes are ignored; successful writes are compared with a new after-snapshot.
4. A [`WorkspaceChangeRecord`] is created, persisted, and emitted as a structured SSE event. The frontend uses that event to update the compact review panel and the detail dialog.
5. Consecutive pending edits for the same file are folded into one logical record. The first
 before-snapshot is retained, while the latest after-snapshot, fingerprint, line counts, and
  diff replace the previous values. Accepting or canceling a record ends that merge window.
6. Accept only changes the record state. Cancel first compares the current filesystem state
with the recorded after-fingerprint; if another process changed the file, rollback is
 rejected to avoid overwriting external work. Otherwise the before-snapshot is restored.

--- 

Metadata is stored per session as JSON, while full snapshots are stored in sidecar JSON files
keyed by change ID. This keeps the chat history format independent from binary file contents
and allows pending changes to be reconstructed after a page refresh or server restart.

Copy and move operations are represented as one record containing both source and destination paths. Directory snapshots recursively capture entries, so restoration can recreate files,directories, and the original non-existent state.