### PR TITLE
feat(edit_file): implement EditFileBrainTool with flat argument handl…

### DIFF
--- a/zihuan_workspace_agent/src/tests/tools/workspace/edit_file.rs
+++ b/zihuan_workspace_agent/src/tests/tools/workspace/edit_file.rs
@@ -14,6 +14,12 @@ fn temp_dir() -> PathBuf {
     path
 }
 
+/// Purpose: Verify that the flat edit_file contract can both replace and delete
+/// a one-based inclusive line range while preserving a trailing newline.
+///
+/// Test Data: A four-line UTF-8 file. First replaces lines 2-3 with two new
+/// lines, then deletes those two lines using an empty replacement_lines array.
+/// Both calls use top-level path, start_line, end_line, and replacement_lines.
 #[test]
 fn test_edit_file_replaces_and_deletes_with_flat_arguments() {
     let directory = temp_dir();
@@ -52,6 +58,12 @@ fn test_edit_file_replaces_and_deletes_with_flat_arguments() {
     fs::remove_dir_all(directory).unwrap();
 }
 
+/// Purpose: Verify that the LLM-facing edit_file schema exposes the flat
+/// contract needed by models that do not reliably populate nested objects.
+///
+/// Test Data: An EditFileBrainTool without a workspace path. Its specification
+/// must require path, start_line, end_line, and replacement_lines at the top
+/// level, and must not include the previous edits array property.
 #[test]
 fn test_edit_file_spec_uses_flat_required_arguments() {
     let tool = EditFileBrainTool {
@@ -84,6 +96,11 @@ fn test_edit_file_spec_uses_flat_required_arguments() {
         .any(|value| value == "replacement_lines"));
 }
 
+/// Purpose: Verify that an incomplete flat edit_file request returns a clear
+/// validation error before reading or writing the target file.
+///
+/// Test Data: A two-line UTF-8 file and an edit request omitting start_line.
+/// Expects a missing-field error and the original file content to remain intact.
 #[test]
 fn test_edit_file_rejects_missing_start_line_without_changing_file() {
     let directory = temp_dir();

--- a/zihuan_workspace_agent/src/tests/tools/workspace/edit_file.rs
+++ b/zihuan_workspace_agent/src/tests/tools/workspace/edit_file.rs
@@ -1,0 +1,113 @@
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::json;
+use zihuan_core::agent::brain::BrainTool;
+
+use crate::tools::workspace_tools::{EditFileBrainTool, DEFAULT_TOOL_EDIT_FILE};
+
+fn temp_dir() -> PathBuf {
+    let suffix = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+    let path = std::env::temp_dir().join(format!("zihuan-edit-file-{}-{suffix}", std::process::id()));
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+
+#[test]
+fn test_edit_file_replaces_and_deletes_with_flat_arguments() {
+    let directory = temp_dir();
+    let file_path = directory.join("sample.txt");
+    fs::write(&file_path, "one\ntwo\nthree\nfour\n").unwrap();
+    let tool = EditFileBrainTool {
+        workspace_path: Some(directory.clone()),
+    };
+
+    let replaced = serde_json::from_str::<serde_json::Value>(&tool.execute(
+        "",
+        &json!({
+            "path": "sample.txt",
+            "start_line": 2,
+            "end_line": 3,
+            "replacement_lines": ["second", "third"]
+        }),
+    ))
+    .unwrap();
+    assert_eq!(replaced["ok"], true);
+    assert_eq!(fs::read_to_string(&file_path).unwrap(), "one\nsecond\nthird\nfour\n");
+
+    let deleted = serde_json::from_str::<serde_json::Value>(&tool.execute(
+        "",
+        &json!({
+            "path": "sample.txt",
+            "start_line": 2,
+            "end_line": 3,
+            "replacement_lines": []
+        }),
+    ))
+    .unwrap();
+    assert_eq!(deleted["ok"], true);
+    assert_eq!(fs::read_to_string(&file_path).unwrap(), "one\nfour\n");
+
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn test_edit_file_spec_uses_flat_required_arguments() {
+    let tool = EditFileBrainTool {
+        workspace_path: None,
+    };
+    let specification = tool.spec();
+    let parameters = specification.parameters();
+
+    assert_eq!(specification.name(), DEFAULT_TOOL_EDIT_FILE);
+    assert!(parameters["properties"].get("edits").is_none());
+    assert!(parameters["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|value| value == "path"));
+    assert!(parameters["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|value| value == "start_line"));
+    assert!(parameters["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|value| value == "end_line"));
+    assert!(parameters["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|value| value == "replacement_lines"));
+}
+
+#[test]
+fn test_edit_file_rejects_missing_start_line_without_changing_file() {
+    let directory = temp_dir();
+    let file_path = directory.join("sample.txt");
+    fs::write(&file_path, "one\ntwo\n").unwrap();
+    let tool = EditFileBrainTool {
+        workspace_path: Some(directory.clone()),
+    };
+
+    let result = serde_json::from_str::<serde_json::Value>(&tool.execute(
+        "",
+        &json!({
+            "path": "sample.txt",
+            "end_line": 2,
+            "replacement_lines": ["changed"]
+        }),
+    ))
+    .unwrap();
+
+    assert!(result["error"]
+        .as_str()
+        .unwrap()
+        .contains("missing field `start_line`"));
+    assert_eq!(fs::read_to_string(&file_path).unwrap(), "one\ntwo\n");
+
+    fs::remove_dir_all(directory).unwrap();
+}

--- a/zihuan_workspace_agent/src/tests/tools/workspace/enhanced_tools.rs
+++ b/zihuan_workspace_agent/src/tests/tools/workspace/enhanced_tools.rs
@@ -5,7 +5,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde_json::json;
 use zihuan_core::agent::brain::BrainTool;
 
-use crate::tools::workspace_tools::{ListDirBrainTool, ReadFileBrainTool, RgBrainTool};
+use crate::tools::workspace_tools::{
+    approve_command, ListDirBrainTool, ReadFileBrainTool, RgBrainTool,
+};
 #[cfg(windows)]
 use crate::tools::workspace_tools::ExecCmdBrainTool;
 
@@ -72,8 +74,18 @@ fn rg_extracts_capture_group_and_deduplicates_values() {
 #[test]
 fn exec_cmd_accepts_environment_and_stdin() {
     let directory = temp_dir();
-    let tool = ExecCmdBrainTool { workspace_path: Some(directory.clone()) };
-        let result = serde_json::from_str::<serde_json::Value>(&tool.execute("", &json!({"command":"$data = [Console]::In.ReadToEnd(); Write-Output ($env:ZIHUAN_TEST + ':' + $data)","env":{"ZIHUAN_TEST":"ok"},"input":"data"}))).unwrap();
+    let session_id = format!("exec-cmd-test-{}", std::process::id());
+    let command = "$data = [Console]::In.ReadToEnd(); Write-Output ($env:ZIHUAN_TEST + ':' + $data)";
+    let tool = ExecCmdBrainTool {
+        workspace_path: Some(directory.clone()),
+        session_id: Some(session_id.clone()),
+    };
+    approve_command(&session_id, command, false);
+    let result = serde_json::from_str::<serde_json::Value>(&tool.execute(
+        "",
+        &json!({"command":command,"env":{"ZIHUAN_TEST":"ok"},"input":"data"}),
+    ))
+    .unwrap();
     assert_eq!(result["ok"], true);
     let output = format!("{}{}", result["stdout"].as_str().unwrap_or_default(), result["stderr"].as_str().unwrap_or_default());
     assert!(output.contains("data"));

--- a/zihuan_workspace_agent/src/tests/tools/workspace/mod.rs
+++ b/zihuan_workspace_agent/src/tests/tools/workspace/mod.rs
@@ -1,5 +1,6 @@
 mod grep;
 mod enhanced_tools;
+mod edit_file;
 mod file_operations;
 mod find_files;
 mod git_status;

--- a/zihuan_workspace_agent/src/tools/workspace_tools/edit_file.rs
+++ b/zihuan_workspace_agent/src/tools/workspace_tools/edit_file.rs
@@ -1,18 +1,101 @@
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
+
 use serde::Deserialize;
 use serde_json::Value;
 use zihuan_core::agent::brain::{BrainTool, ToolExecutionResource};
-use zihuan_core::llm::tooling::FunctionTool;
-use zihuan_core::llm::tooling::StaticFunctionToolSpec;
+use zihuan_core::llm::tooling::{FunctionTool, StaticFunctionToolSpec};
+
 use super::shared::{json_error, path_resource, resolve_tool_path, success_json};
-pub(crate) const DEFAULT_TOOL_EDIT_FILE:&str="edit_file";
-#[derive(Debug,Deserialize)]struct EditFileArgs{path:String,edits:Vec<LineEditSpec>}
-#[derive(Debug,Clone,Deserialize)]struct LineEditSpec{start_line:usize,end_line:usize,replacement_lines:Vec<String>}
-#[derive(Debug,Clone)]pub(crate)struct EditFileBrainTool{pub(crate)workspace_path:Option<PathBuf>}
-impl BrainTool for EditFileBrainTool{
- fn spec(&self)->Arc<dyn FunctionTool>{Arc::new(StaticFunctionToolSpec{name:DEFAULT_TOOL_EDIT_FILE,description:"Replace or delete existing file lines using 1-based inclusive line ranges",parameters:serde_json::json!({"type":"object","properties":{"path":{"type":"string"},"edits":{"type":"array","items":{"type":"object","properties":{"start_line":{"type":"integer","minimum":1},"end_line":{"type":"integer","minimum":1},"replacement_lines":{"type":"array","items":{"type":"string"}}},"required":["start_line","end_line","replacement_lines"]}}},"required":["path","edits"]})})}
- fn execute(&self,_:&str,a:&Value)->String{let args:EditFileArgs=match serde_json::from_value(a.clone()){Ok(v)=>v,Err(e)=>return json_error(format!("invalid edit_file arguments: {e}"))};let path=match resolve_tool_path(self.workspace_path.as_deref(),&args.path){Ok(v)=>v,Err(e)=>return json_error(e.to_string())};let original=match fs::read_to_string(&path){Ok(v)=>v,Err(e)=>return json_error(format!("failed to read file '{}': {e}",path.display()))};let trailing=original.ends_with('\n');let mut lines:Vec<String>=original.lines().map(ToOwned::to_owned).collect();let mut edits=args.edits;edits.sort_by(|a,b|b.start_line.cmp(&a.start_line).then_with(||b.end_line.cmp(&a.end_line)));for edit in edits{if edit.start_line==0||edit.end_line==0||edit.start_line>edit.end_line{return json_error(format!("invalid line range: start_line={} end_line={}",edit.start_line,edit.end_line))}if edit.end_line>lines.len(){return json_error(format!("line range [{}-{}] is out of bounds for file '{}' with {} lines",edit.start_line,edit.end_line,path.display(),lines.len()))}lines.splice(edit.start_line-1..edit.end_line,edit.replacement_lines);}let mut rewritten=lines.join("\n");if trailing&&!rewritten.is_empty(){rewritten.push('\n')}if let Err(e)=fs::write(&path,rewritten){return json_error(format!("failed to write edited file '{}': {e}",path.display()))}success_json(serde_json::json!({"ok":true,"path":path.display().to_string(),"line_count":lines.len()}))}
- fn execution_resource(&self,a:&Value)->ToolExecutionResource{serde_json::from_value::<EditFileArgs>(a.clone()).map(|v|path_resource(self.workspace_path.as_deref(),&v.path,true)).unwrap_or(ToolExecutionResource::Exclusive)}
+
+pub(crate) const DEFAULT_TOOL_EDIT_FILE: &str = "edit_file";
+
+#[derive(Debug, Deserialize)]
+struct EditFileArgs {
+    path: String,
+    start_line: usize,
+    end_line: usize,
+    replacement_lines: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct EditFileBrainTool {
+    pub(crate) workspace_path: Option<PathBuf>,
+}
+
+impl BrainTool for EditFileBrainTool {
+    fn spec(&self) -> Arc<dyn FunctionTool> {
+        Arc::new(StaticFunctionToolSpec {
+            name: DEFAULT_TOOL_EDIT_FILE,
+            description: "Replace or delete one existing 1-based inclusive line range. Supply path, start_line, end_line, and replacement_lines at the top level. Call once per edit.",
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string" },
+                    "start_line": { "type": "integer", "minimum": 1 },
+                    "end_line": { "type": "integer", "minimum": 1 },
+                    "replacement_lines": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                    }
+                },
+                "required": ["path", "start_line", "end_line", "replacement_lines"]
+            }),
+        })
+    }
+
+    fn execute(&self, _: &str, arguments: &Value) -> String {
+        let args: EditFileArgs = match serde_json::from_value(arguments.clone()) {
+            Ok(value) => value,
+            Err(error) => return json_error(format!("invalid edit_file arguments: {error}")),
+        };
+        let path = match resolve_tool_path(self.workspace_path.as_deref(), &args.path) {
+            Ok(path) => path,
+            Err(error) => return json_error(error.to_string()),
+        };
+        let original = match fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(error) => return json_error(format!("failed to read file '{}': {error}", path.display())),
+        };
+        let trailing_newline = original.ends_with('\n');
+        let mut lines: Vec<String> = original.lines().map(ToOwned::to_owned).collect();
+
+        if args.start_line == 0 || args.end_line == 0 || args.start_line > args.end_line {
+            return json_error(format!(
+                "invalid line range: start_line={} end_line={}",
+                args.start_line, args.end_line
+            ));
+        }
+        if args.end_line > lines.len() {
+            return json_error(format!(
+                "line range [{}-{}] is out of bounds for file '{}' with {} lines",
+                args.start_line,
+                args.end_line,
+                path.display(),
+                lines.len()
+            ));
+        }
+
+        lines.splice(args.start_line - 1..args.end_line, args.replacement_lines);
+        let mut rewritten = lines.join("\n");
+        if trailing_newline && !rewritten.is_empty() {
+            rewritten.push('\n');
+        }
+        if let Err(error) = fs::write(&path, rewritten) {
+            return json_error(format!("failed to write edited file '{}': {error}", path.display()));
+        }
+
+        success_json(serde_json::json!({
+            "ok": true,
+            "path": path.display().to_string(),
+            "line_count": lines.len(),
+        }))
+    }
+
+    fn execution_resource(&self, arguments: &Value) -> ToolExecutionResource {
+        serde_json::from_value::<EditFileArgs>(arguments.clone())
+            .map(|args| path_resource(self.workspace_path.as_deref(), &args.path, true))
+            .unwrap_or(ToolExecutionResource::Exclusive)
+    }
 }


### PR DESCRIPTION
## Changes Details

### Key Features

- Implemented new `EditFileBrainTool` with flat argument structure support
- Uses 1-based inclusive line range for file editing operations
- Supports both file content replacement and deletion operations
- Preserves original file trailing newlines

### Technical Specifications

#### Parameter Structure
The new flat parameter structure requires all the following fields at the top level:
- `path`: File path (string)
- `start_line`: Starting line number (integer, minimum value 1)
- `end_line`: Ending line number (integer, minimum value 1)
- `replacement_lines`: Replacement line contents (array of strings)

#### Workflow
1. Tool receives a JSON object containing the above parameters
2. Parses and validates parameter validity
3. Reads target file content
4. Replaces content according to specified line range
5. Writes modified file content
6. Returns operation result and file statistics

### Usage Example

```json
{
  "path": "example.txt",
  "start_line": 2,
  "end_line": 3,
  "replacement_lines": ["New line 1", "New line 2"]
}
```