### PR TITLE
Features/enhance workspace diff display

### DIFF
--- a/webui/src/admin/composables/useChat.ts
+++ b/webui/src/admin/composables/useChat.ts
@@ -511,15 +511,6 @@ const agentsMdEditorContent = ref("");
 const selectedWorkspaceChange = computed(() =>
   workspaceChanges.value.find((item) => item.change_id === selectedWorkspaceChangeId.value) ?? workspaceChanges.value[0] ?? null,
 );
-const workspaceFileGroups = computed(() => {
-  const groups = new Map<string, WorkspaceChange[]>();
-  for (const change of workspaceChanges.value) {
-    const group = groups.get(change.display_path) ?? [];
-    group.push(change);
-    groups.set(change.display_path, group);
-  }
-  return Array.from(groups, ([path, changes]) => ({ path, changes }));
-});
 const askUserAnswer = ref("");
 const canSubmitAskUser = computed(() =>
   isChatEligible.value &&
@@ -1271,14 +1262,23 @@ async function openSession(sessionId: string) {
 
 function applyWorkspaceChange(change: WorkspaceChange) {
   const index = workspaceChanges.value.findIndex((item) => item.change_id === change.change_id);
-  if (index >= 0) {
+  if (change.status !== "pending") {
+    if (index >= 0) workspaceChanges.value.splice(index, 1);
+  } else if (index >= 0) {
     workspaceChanges.value[index] = change;
-  } else if (change.status === "pending") {
+  } else {
     workspaceChanges.value.push(change);
   }
-  if (!selectedWorkspaceChangeId.value) {
-    selectedWorkspaceChangeId.value = change.change_id;
+  if (!selectedWorkspaceChangeId.value || selectedWorkspaceChangeId.value === change.change_id) {
+    selectedWorkspaceChangeId.value = workspaceChanges.value[0]?.change_id ?? null;
   }
+}
+
+function workspaceChangePathLabel(change: WorkspaceChange): string {
+  if (change.source_path && change.destination_path) {
+    return `${change.source_path} → ${change.destination_path}`;
+  }
+  return change.display_path;
 }
 
 function openWorkspaceChange(change: WorkspaceChange) {
@@ -1316,21 +1316,6 @@ async function cancelWorkspaceChange(change: WorkspaceChange) {
     workspaceChangeDialogOpen.value = false;
   } catch (error) {
     workspaceChangeError.value = `撤销失败: ${(error as Error).message}`;
-  }
-}
-
-async function acceptWorkspaceFile(path: string) {
-  const changes = workspaceChanges.value.filter((item) => item.display_path === path);
-  for (const change of changes) {
-    await acceptWorkspaceChange(change);
-  }
-}
-
-async function cancelWorkspaceFile(path: string) {
-  const changes = workspaceChanges.value.filter((item) => item.display_path === path);
-  for (const change of changes) {
-    await cancelWorkspaceChange(change);
-    if (workspaceChangeError.value) break;
   }
 }
 
@@ -2084,7 +2069,6 @@ onUnmounted(() => {
     selectedAgentAvatarFallback,
     pendingAskUser,
     workspaceChanges,
-    workspaceFileGroups,
     selectedWorkspaceChange,
     selectedWorkspaceChangeId,
     workspaceChangeDialogOpen,
@@ -2150,8 +2134,7 @@ onUnmounted(() => {
     closeWorkspaceChange,
     acceptWorkspaceChange,
     cancelWorkspaceChange,
-    acceptWorkspaceFile,
-    cancelWorkspaceFile,
+    workspaceChangePathLabel,
     pruneFailedAssistantPlaceholder,
     applyInferenceFailure,
     reloadSessions,

--- a/webui/src/admin/view/Chat.vue
+++ b/webui/src/admin/view/Chat.vue
@@ -967,7 +967,6 @@
                 @click="openWorkspaceChange(change)"
               >
                 <span>{{ workspaceChangePathLabel(change) }}</span>
-                <small>合并 {{ change.merged_count }} 次</small>
               </button>
               <div class="workspace-change-file-actions">
                 <button class="workspace-change-accept" @click="acceptWorkspaceChange(change)">Accept</button>
@@ -987,7 +986,6 @@
                 <span v-if="selectedWorkspaceChange.source_path && selectedWorkspaceChange.destination_path">
                   {{ selectedWorkspaceChange.source_path }} → {{ selectedWorkspaceChange.destination_path }}
                 </span>
-                <span>合并：{{ selectedWorkspaceChange.merged_count }} 次</span>
                 <span>行数：+{{ selectedWorkspaceChange.added_lines }} / -{{ selectedWorkspaceChange.removed_lines }}</span>
               </div>
               <div class="workspace-change-paths">

--- a/webui/src/admin/view/Chat.vue
+++ b/webui/src/admin/view/Chat.vue
@@ -680,7 +680,7 @@
                     <div v-for="change in workspaceChanges" :key="change.change_id" class="workspace-change-row">
                       <button class="workspace-change-summary" @click="openWorkspaceChange(change)">
                         <span class="workspace-change-operation">{{ change.operation }}</span>
-                        <span class="workspace-change-path" :title="change.paths.join(' → ')">{{ change.display_path }}</span>
+                        <span class="workspace-change-path" :title="workspaceChangePathLabel(change)">{{ workspaceChangePathLabel(change) }}</span>
                         <span class="workspace-change-lines">+{{ change.added_lines }} / -{{ change.removed_lines }}</span>
                       </button>
                       <button class="workspace-change-accept" @click="acceptWorkspaceChange(change)">Accept</button>
@@ -960,30 +960,33 @@
         <div class="workspace-change-dialog" role="dialog" aria-modal="true" aria-label="文件更改">
           <aside class="workspace-change-dialog-sidebar">
             <strong>文件更改</strong>
-            <div v-for="group in workspaceFileGroups" :key="group.path" class="workspace-change-file-row">
+            <div v-for="change in workspaceChanges" :key="change.change_id" class="workspace-change-file-row">
               <button
                 class="workspace-change-file"
-                :class="{ active: selectedWorkspaceChange?.display_path === group.path }"
-                @click="openWorkspaceChange(group.changes[0])"
+                :class="{ active: selectedWorkspaceChange?.change_id === change.change_id }"
+                @click="openWorkspaceChange(change)"
               >
-                <span>{{ group.path }}</span>
-                <small>{{ group.changes.length }} 处更改</small>
+                <span>{{ workspaceChangePathLabel(change) }}</span>
+                <small>合并 {{ change.merged_count }} 次</small>
               </button>
               <div class="workspace-change-file-actions">
-                <button class="workspace-change-accept" @click="acceptWorkspaceFile(group.path)">Accept</button>
-                <button class="workspace-change-reject" @click="cancelWorkspaceFile(group.path)">Reject</button>
+                <button class="workspace-change-accept" @click="acceptWorkspaceChange(change)">Accept</button>
+                <button class="workspace-change-reject" @click="cancelWorkspaceChange(change)">Reject</button>
                 <button class="workspace-change-cancel" @click="closeWorkspaceChange">Cancel</button>
               </div>
             </div>
           </aside>
           <section class="workspace-change-dialog-main">
             <header class="workspace-change-dialog-header">
-              <strong>{{ selectedWorkspaceChange?.display_path || "文件更改" }}</strong>
+              <strong>{{ selectedWorkspaceChange ? workspaceChangePathLabel(selectedWorkspaceChange) : "文件更改" }}</strong>
               <button aria-label="关闭文件更改" @click="closeWorkspaceChange"><CloseIcon /></button>
             </header>
             <div v-if="selectedWorkspaceChange" class="workspace-change-detail">
               <div class="workspace-change-detail-meta">
                 <span>操作：{{ selectedWorkspaceChange.operation }}</span>
+                <span v-if="selectedWorkspaceChange.source_path && selectedWorkspaceChange.destination_path">
+                  {{ selectedWorkspaceChange.source_path }} → {{ selectedWorkspaceChange.destination_path }}
+                </span>
                 <span>合并：{{ selectedWorkspaceChange.merged_count }} 次</span>
                 <span>行数：+{{ selectedWorkspaceChange.added_lines }} / -{{ selectedWorkspaceChange.removed_lines }}</span>
               </div>
@@ -1462,7 +1465,6 @@ const {
   pendingAskUser,
   workspaceChanges,
   workspaceTasks,
-  workspaceFileGroups,
   selectedWorkspaceChange,
   workspaceChangeDialogOpen,
   workspaceChangeError,
@@ -1513,8 +1515,7 @@ const {
   closeWorkspaceChange,
   acceptWorkspaceChange,
   cancelWorkspaceChange,
-  acceptWorkspaceFile,
-  cancelWorkspaceFile,
+  workspaceChangePathLabel,
   pruneFailedAssistantPlaceholder,
   applyInferenceFailure,
   reloadSessions,

--- a/webui/src/api/client.ts
+++ b/webui/src/api/client.ts
@@ -492,7 +492,7 @@ export interface WorkspaceTask {
 }
 
 export type WorkspaceChangeOperation = "create" | "edit" | "delete" | "copy" | "move";
-export type WorkspaceChangeStatus = "pending" | "accepted" | "canceled";
+export type WorkspaceChangeStatus = "pending" | "resolved" | "accepted" | "canceled";
 export interface WorkspaceDiffLine {
   kind: "added" | "removed" | "context";
   line: string;
@@ -506,6 +506,8 @@ export interface WorkspaceChange {
   operation: WorkspaceChangeOperation;
   paths: string[];
   display_path: string;
+  source_path?: string;
+  destination_path?: string;
   added_lines: number;
   removed_lines: number;
   before_fingerprint: string;

--- a/zihuan_workspace_agent/src/api/workspace_changes.rs
+++ b/zihuan_workspace_agent/src/api/workspace_changes.rs
@@ -15,9 +15,10 @@
 //!    successful writes are compared with a new after-snapshot.
 //! 4. A [`WorkspaceChangeRecord`] is created, persisted, and emitted as a structured SSE event.
 //!    The frontend uses that event to update the compact review panel and the detail dialog.
-//! 5. Consecutive pending edits for the same file are folded into one logical record. The first
-//!    before-snapshot is retained, while the latest after-snapshot, fingerprint, line counts, and
-//!    diff replace the previous values. Accepting or canceling a record ends that merge window.
+//! 5. Pending records whose affected paths overlap are folded into one logical record across chat
+//!    rounds. The first before-snapshot for every path is retained, while the latest after-state,
+//!    fingerprint, line counts, and diff replace the previous values. Accepting or canceling a
+//!    record ends that merge window.
 //! 6. Accept only changes the record state. Cancel first compares the current filesystem state
 //!    with the recorded after-fingerprint; if another process changed the file, rollback is
 //!    rejected to avoid overwriting external work. Otherwise the before-snapshot is restored.
@@ -30,7 +31,7 @@
 //! paths. Directory snapshots recursively capture entries, so restoration can recreate files,
 //! directories, and the original non-existent state.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -106,6 +107,8 @@ pub enum WorkspaceChangeOperation {
 pub enum WorkspaceChangeStatus {
     /// The change is still visible in the dashboard review panel and can be handled by the user.
     Pending,
+    /// The final filesystem state matches the original snapshot, so no review is needed unless a later write reopens it.
+    Resolved,
     /// The user accepted the already-written filesystem state.
     Accepted,
     /// The user canceled the change and the before-snapshot was restored.
@@ -162,6 +165,12 @@ pub struct WorkspaceChangeRecord {
     pub paths: Vec<String>,
     /// Primary path shown in compact lists and as the file grouping key.
     pub display_path: String,
+    /// Original source path for a copy or move operation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_path: Option<String>,
+    /// Final destination path for a copy or move operation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destination_path: Option<String>,
     /// Number of lines present only in the after-state summary.
     pub added_lines: usize,
     /// Number of lines present only in the before-state summary.
@@ -172,7 +181,7 @@ pub struct WorkspaceChangeRecord {
     pub after_fingerprint: String,
     /// Current review state.
     pub status: WorkspaceChangeStatus,
-    /// Number of edit tool calls folded into this logical record.
+    /// Number of successful workspace tool calls folded into this logical record.
     pub merged_count: usize,
     /// Coarse unified-style line list used by the dashboard detail dialog.
     #[serde(default)]
@@ -191,6 +200,8 @@ struct PendingOperation {
     session_id: String,
     operation: WorkspaceChangeOperation,
     paths: Vec<PathBuf>,
+    source_path: Option<PathBuf>,
+    destination_path: Option<PathBuf>,
     before: Vec<PathSnapshot>,
 }
 
@@ -230,18 +241,25 @@ impl WorkspaceChangeRecorder {
             .into_iter()
             .filter_map(|path| resolve_path(self.workspace_path.as_deref(), &path))
             .collect::<Vec<_>>();
+        let source_path = matches!(operation, WorkspaceChangeOperation::Copy | WorkspaceChangeOperation::Move)
+            .then(|| paths.first().cloned())
+            .flatten();
+        let destination_path = matches!(operation, WorkspaceChangeOperation::Copy | WorkspaceChangeOperation::Move)
+            .then(|| paths.get(1).cloned())
+            .flatten();
         let before = paths.iter().map(|path| snapshot(path)).collect::<Vec<_>>();
         started().lock().expect("workspace change lock poisoned").insert(call_id.to_string(), PendingOperation {
-            session_id: self.session_id.clone(), operation, paths, before,
+            session_id: self.session_id.clone(), operation, paths, source_path, destination_path, before,
         });
     }
 
     /// Finalizes a tool call after the tool has written to disk.
     ///
     /// A valid successful JSON result must contain `{"ok": true}`. The method then snapshots the
-    /// affected paths again, ignores no-op changes, merges compatible pending edits, persists the
-    /// record and returns it for SSE emission. Persistence errors are intentionally best-effort
-    /// here because the existing tool result must not be changed after the tool has completed.
+    /// affected paths again, ignores no-op changes, merges overlapping pending changes, persists
+    /// the record and returns it for SSE emission. Persistence errors are intentionally
+    /// best-effort here because the existing tool result must not be changed after the tool has
+    /// completed.
     pub fn finish(&self, call_id: &str, result: &str) -> Option<WorkspaceChangeRecord> {
         let operation = started().lock().ok()?.remove(call_id)?;
         let result_json: Value = serde_json::from_str(result).ok()?;
@@ -258,6 +276,8 @@ impl WorkspaceChangeRecorder {
             operation: operation.operation,
             paths: operation.paths.iter().map(|path| display_path(self.workspace_path.as_deref(), path)).collect(),
             display_path: operation.paths.first().map(|path| display_path(self.workspace_path.as_deref(), path)).unwrap_or_default(),
+            source_path: operation.source_path.as_deref().map(|path| display_path(self.workspace_path.as_deref(), path)),
+            destination_path: operation.destination_path.as_deref().map(|path| display_path(self.workspace_path.as_deref(), path)),
             added_lines: line_delta(&operation.before, &after).0,
             removed_lines: line_delta(&operation.before, &after).1,
             before_fingerprint: fingerprint(&operation.before),
@@ -271,23 +291,143 @@ impl WorkspaceChangeRecorder {
 
         let mut all = records().lock().expect("workspace change lock poisoned");
         let list = all.entry(self.session_id.clone()).or_default();
-        if let Some(index) = list.iter().rposition(|item| matches!(item.status, WorkspaceChangeStatus::Pending) && item.paths == record.paths && matches!(item.operation, WorkspaceChangeOperation::Edit) && matches!(record.operation, WorkspaceChangeOperation::Edit)) {
-            let previous = &mut list[index];
-            previous.after = record.after.clone();
-            previous.after_fingerprint = record.after_fingerprint.clone();
-            previous.added_lines += record.added_lines;
-            previous.removed_lines += record.removed_lines;
-            previous.diff = record.diff.clone();
-            previous.merged_count += 1;
-            let output = previous.clone();
-            persist_snapshot(&output).ok();
-            persist_session(&self.session_id, list).ok();
-            return Some(output);
+        let matching_indices = matching_pending_indices(list, &record.paths);
+        if !matching_indices.is_empty() {
+            return merge_pending_records(list, matching_indices, record, self.workspace_path.as_deref(), &self.session_id);
         }
         persist_snapshot(&record).ok();
         list.push(record.clone());
         persist_session(&self.session_id, list).ok();
         Some(record)
+    }
+}
+
+fn matching_pending_indices(records: &[WorkspaceChangeRecord], paths: &[String]) -> Vec<usize> {
+    let paths = paths.iter().collect::<HashSet<_>>();
+    records
+        .iter()
+        .enumerate()
+        .filter_map(|(index, record)| {
+            (matches!(record.status, WorkspaceChangeStatus::Pending | WorkspaceChangeStatus::Resolved)
+                && record.paths.iter().any(|path| paths.contains(path)))
+            .then_some(index)
+        })
+        .collect()
+}
+
+fn merge_pending_records(
+    records: &mut Vec<WorkspaceChangeRecord>,
+    matching_indices: Vec<usize>,
+    incoming: WorkspaceChangeRecord,
+    workspace: Option<&Path>,
+    session_id: &str,
+) -> Option<WorkspaceChangeRecord> {
+    let insertion_index = *matching_indices.first()?;
+    let mut merged_records = matching_indices
+        .iter()
+        .rev()
+        .map(|index| records.remove(*index))
+        .collect::<Vec<_>>();
+    merged_records.reverse();
+
+    let change_id = merged_records.first()?.change_id.clone();
+    let removed_change_ids = merged_records
+        .iter()
+        .skip(1)
+        .map(|record| record.change_id.clone())
+        .collect::<Vec<_>>();
+    let before = merge_before_snapshots(&merged_records, &incoming.before);
+    let after = before
+        .iter()
+        .map(|snapshot_item| snapshot(Path::new(&snapshot_item.path)))
+        .collect::<Vec<_>>();
+    let (operation, source_path, destination_path) = merged_operation(&merged_records, &incoming, &before, &after);
+    let paths = before
+        .iter()
+        .map(|snapshot_item| display_path(workspace, Path::new(&snapshot_item.path)))
+        .collect::<Vec<_>>();
+    let display_path = source_path.clone().unwrap_or_else(|| paths.first().cloned().unwrap_or_default());
+    let mut merged = WorkspaceChangeRecord {
+        change_id,
+        session_id: incoming.session_id.clone(),
+        operation,
+        paths,
+        display_path,
+        source_path,
+        destination_path,
+        added_lines: line_delta(&before, &after).0,
+        removed_lines: line_delta(&before, &after).1,
+        before_fingerprint: fingerprint(&before),
+        after_fingerprint: fingerprint(&after),
+        status: WorkspaceChangeStatus::Pending,
+        merged_count: merged_records.iter().map(|record| record.merged_count).sum::<usize>() + incoming.merged_count,
+        diff: build_diff(&before, &after),
+        before,
+        after,
+    };
+
+    if snapshots_equal(&merged.before, &merged.after) {
+        merged.status = WorkspaceChangeStatus::Resolved;
+    }
+
+    persist_snapshot(&merged).ok();
+    for change_id in removed_change_ids {
+        remove_snapshot(&change_id);
+    }
+    records.insert(insertion_index, merged.clone());
+    persist_session(session_id, records).ok();
+    Some(merged)
+}
+
+fn merge_before_snapshots(records: &[WorkspaceChangeRecord], incoming: &[PathSnapshot]) -> Vec<PathSnapshot> {
+    let mut snapshots = BTreeMap::new();
+    for record in records {
+        for snapshot_item in &record.before {
+            snapshots.entry(snapshot_item.path.clone()).or_insert_with(|| snapshot_item.clone());
+        }
+    }
+    for snapshot_item in incoming {
+        snapshots.entry(snapshot_item.path.clone()).or_insert_with(|| snapshot_item.clone());
+    }
+    snapshots.into_values().collect()
+}
+
+fn merged_operation(
+    records: &[WorkspaceChangeRecord],
+    incoming: &WorkspaceChangeRecord,
+    before: &[PathSnapshot],
+    after: &[PathSnapshot],
+) -> (WorkspaceChangeOperation, Option<String>, Option<String>) {
+    if matches!(incoming.operation, WorkspaceChangeOperation::Copy) {
+        return (WorkspaceChangeOperation::Copy, incoming.source_path.clone(), incoming.destination_path.clone());
+    }
+    if matches!(incoming.operation, WorkspaceChangeOperation::Move) {
+        let source_path = records
+            .iter()
+            .rev()
+            .find(|record| {
+                matches!(record.operation, WorkspaceChangeOperation::Move)
+                    && record.destination_path == incoming.source_path
+            })
+            .and_then(|record| record.source_path.clone())
+            .or_else(|| incoming.source_path.clone());
+        return (WorkspaceChangeOperation::Move, source_path, incoming.destination_path.clone());
+    }
+    if let Some(record) = records.iter().rev().find(|record| {
+        matches!(record.operation, WorkspaceChangeOperation::Copy | WorkspaceChangeOperation::Move)
+    }) {
+        return (record.operation.clone(), record.source_path.clone(), record.destination_path.clone());
+    }
+    (derived_operation(before, after), None, None)
+}
+
+fn derived_operation(before: &[PathSnapshot], after: &[PathSnapshot]) -> WorkspaceChangeOperation {
+    let existed_before = before.iter().any(|snapshot_item| snapshot_item.exists);
+    let exists_after = after.iter().any(|snapshot_item| snapshot_item.exists);
+    match (existed_before, exists_after) {
+        (false, true) => WorkspaceChangeOperation::Create,
+        (true, false) => WorkspaceChangeOperation::Delete,
+        _ => WorkspaceChangeOperation::Edit,
     }
 }
 
@@ -435,6 +575,11 @@ fn session_file(session_id: &str) -> PathBuf { storage_dir().join(format!("{sess
 
 /// Stores private before/after snapshots separately from the public record metadata.
 fn persist_snapshot(record: &WorkspaceChangeRecord) -> Result<()> { let path = storage_dir().join(format!("{}-snapshot.json", record.change_id)); fs::create_dir_all(storage_dir())?; let data = serde_json::to_vec(&(record.before.clone(), record.after.clone())).map_err(|e| zihuan_core::string_error!("{}", e))?; fs::write(path, data)?; Ok(()) }
+
+fn remove_snapshot(change_id: &str) {
+    let path = storage_dir().join(format!("{change_id}-snapshot.json"));
+    let _ = fs::remove_file(path);
+}
 
 /// Writes the session's complete record list so status changes and merge results survive restart.
 fn persist_session(session_id: &str, items: &[WorkspaceChangeRecord]) -> Result<()> { fs::create_dir_all(storage_dir())?; let data = serde_json::to_vec_pretty(items).map_err(|e| zihuan_core::string_error!("{}", e))?; fs::write(session_file(session_id), data)?; Ok(()) }

--- a/zihuan_workspace_agent/src/tests/api/workspace_changes.rs
+++ b/zihuan_workspace_agent/src/tests/api/workspace_changes.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::api::workspace_changes::{
-    accept, cancel, WorkspaceChangeOperation, WorkspaceChangeRecorder,
+    accept, cancel, pending, WorkspaceChangeOperation, WorkspaceChangeRecorder,
 };
 
 fn temp_workspace() -> PathBuf {
@@ -11,45 +11,185 @@ fn temp_workspace() -> PathBuf {
     std::env::temp_dir().join(format!("zihuan-workspace-change-{suffix}"))
 }
 
-/// Purpose: Verify consecutive edits to one file share one merged change record and can be rolled back atomically.
-/// TestData: A two-line UTF-8 file, followed by two successful edits changing one line each.
+/// Purpose: Verify consecutive edits share one logical change and Reject restores the original file.
+/// Test Data: `teyvat.txt` starts with Mondstadt and Liyue, then changes to Inazuma and Sumeru.
 #[test]
 fn edit_changes_merge_and_cancel_restores_original_content() {
     let root = temp_workspace();
     let session_id = format!("test-session-{}", root.file_name().unwrap().to_string_lossy());
     fs::create_dir_all(&root).unwrap();
-    let path = root.join("note.txt");
-    fs::write(&path, "one\ntwo\n").unwrap();
+    let path = root.join("teyvat.txt");
+    fs::write(&path, "Mondstadt\nLiyue\n").unwrap();
     let recorder = WorkspaceChangeRecorder::new(&session_id, Some(root.to_string_lossy().to_string()));
-    let args = serde_json::json!({ "path": "note.txt" });
+    let args = serde_json::json!({ "path": "teyvat.txt" });
 
     recorder.start("first", WorkspaceChangeOperation::Edit, &args);
-    fs::write(&path, "ONE\ntwo\n").unwrap();
+    fs::write(&path, "Inazuma\nLiyue\n").unwrap();
     let first = recorder.finish("first", r#"{"ok":true}"#).unwrap();
     recorder.start("second", WorkspaceChangeOperation::Edit, &args);
-    fs::write(&path, "ONE\nTWO\n").unwrap();
+    fs::write(&path, "Inazuma\nSumeru\n").unwrap();
     let second = recorder.finish("second", r#"{"ok":true}"#).unwrap();
 
     assert_eq!(first.change_id, second.change_id);
     assert_eq!(second.merged_count, 2);
     cancel(&session_id, &second.change_id).unwrap();
-    assert_eq!(fs::read_to_string(&path).unwrap(), "one\ntwo\n");
+    assert_eq!(fs::read_to_string(&path).unwrap(), "Mondstadt\nLiyue\n");
     let _ = fs::remove_dir_all(root);
 }
 
-/// Purpose: Verify Accept marks a change as handled without writing or altering the changed file.
-/// TestData: A newly created file containing the text `kept` and one pending create operation.
+/// Purpose: Verify Accept marks a change as handled without changing its final filesystem content.
+/// Test Data: A new `nahida-note.txt` file containing a short Sumeru research note.
 #[test]
 fn accept_does_not_change_disk() {
     let root = temp_workspace();
     let session_id = format!("accept-session-{}", root.file_name().unwrap().to_string_lossy());
     fs::create_dir_all(&root).unwrap();
-    let path = root.join("created.txt");
+    let path = root.join("nahida-note.txt");
     let recorder = WorkspaceChangeRecorder::new(&session_id, Some(root.to_string_lossy().to_string()));
-    recorder.start("create", WorkspaceChangeOperation::Create, &serde_json::json!({ "path": "created.txt" }));
-    fs::write(&path, "kept").unwrap();
+    recorder.start("create", WorkspaceChangeOperation::Create, &serde_json::json!({ "path": "nahida-note.txt" }));
+    fs::write(&path, "Nahida studies Irminsul.\n").unwrap();
     let change = recorder.finish("create", r#"{"ok":true}"#).unwrap();
+
     accept(&session_id, &change.change_id).unwrap();
-    assert_eq!(fs::read_to_string(&path).unwrap(), "kept");
+    assert_eq!(fs::read_to_string(&path).unwrap(), "Nahida studies Irminsul.\n");
+    let _ = fs::remove_dir_all(root);
+}
+
+/// Purpose: Verify create-delete-create collapses into one final create record with the original rollback baseline.
+/// Test Data: `paimon-guide.md` is first created with Mondstadt notes, deleted, then recreated with Liyue notes.
+#[test]
+fn create_delete_create_merges_into_one_pending_change() {
+    let root = temp_workspace();
+    let session_id = format!("create-delete-create-{}", root.file_name().unwrap().to_string_lossy());
+    fs::create_dir_all(&root).unwrap();
+    let path = root.join("paimon-guide.md");
+    let recorder = WorkspaceChangeRecorder::new(&session_id, Some(root.to_string_lossy().to_string()));
+    let args = serde_json::json!({ "path": "paimon-guide.md" });
+
+    recorder.start("create-first", WorkspaceChangeOperation::Create, &args);
+    fs::write(&path, "Mondstadt has dandelion wine.\n").unwrap();
+    let first = recorder.finish("create-first", r#"{"ok":true}"#).unwrap();
+    recorder.start("delete", WorkspaceChangeOperation::Delete, &args);
+    fs::remove_file(&path).unwrap();
+    let resolved = recorder.finish("delete", r#"{"ok":true}"#).unwrap();
+    recorder.start("create-second", WorkspaceChangeOperation::Create, &args);
+    fs::write(&path, "Liyue has lantern rite.\n").unwrap();
+    let final_change = recorder.finish("create-second", r#"{"ok":true}"#).unwrap();
+
+    assert!(matches!(resolved.status, crate::api::workspace_changes::WorkspaceChangeStatus::Resolved));
+    assert_eq!(first.change_id, final_change.change_id);
+    assert_eq!(final_change.merged_count, 3);
+    assert!(matches!(final_change.operation, WorkspaceChangeOperation::Create));
+    assert_eq!(pending(&session_id).unwrap().len(), 1);
+    cancel(&session_id, &final_change.change_id).unwrap();
+    assert!(!path.exists());
+    let _ = fs::remove_dir_all(root);
+}
+
+/// Purpose: Verify a change that returns to its original content no longer appears as pending.
+/// Test Data: `b.txt` changes from a Mondstadt greeting to a Liyue greeting and then back again.
+#[test]
+fn returning_to_the_original_content_resolves_the_change() {
+    let root = temp_workspace();
+    let session_id = format!("resolved-change-{}", root.file_name().unwrap().to_string_lossy());
+    fs::create_dir_all(&root).unwrap();
+    let path = root.join("b.txt");
+    fs::write(&path, "Welcome to Mondstadt.\n").unwrap();
+    let recorder = WorkspaceChangeRecorder::new(&session_id, Some(root.to_string_lossy().to_string()));
+    let args = serde_json::json!({ "path": "b.txt" });
+
+    recorder.start("liyue", WorkspaceChangeOperation::Edit, &args);
+    fs::write(&path, "Welcome to Liyue Harbor.\n").unwrap();
+    recorder.finish("liyue", r#"{"ok":true}"#).unwrap();
+    recorder.start("mondstadt", WorkspaceChangeOperation::Edit, &args);
+    fs::write(&path, "Welcome to Mondstadt.\n").unwrap();
+    let resolved = recorder.finish("mondstadt", r#"{"ok":true}"#).unwrap();
+
+    assert!(matches!(resolved.status, crate::api::workspace_changes::WorkspaceChangeStatus::Resolved));
+    assert!(pending(&session_id).unwrap().is_empty());
+    let _ = fs::remove_dir_all(root);
+}
+
+/// Purpose: Verify a pending file change remains merged when a later chat round creates a new recorder for the same session.
+/// Test Data: `b.txt` changes from Mondstadt to Inazuma in round one, then to Fontaine in round two.
+#[test]
+fn later_chat_round_merges_with_the_existing_pending_change() {
+    let root = temp_workspace();
+    let session_id = format!("multi-round-{}", root.file_name().unwrap().to_string_lossy());
+    fs::create_dir_all(&root).unwrap();
+    let path = root.join("b.txt");
+    fs::write(&path, "Mondstadt\n").unwrap();
+    let args = serde_json::json!({ "path": "b.txt" });
+
+    let first_round = WorkspaceChangeRecorder::new(&session_id, Some(root.to_string_lossy().to_string()));
+    first_round.start("round-one", WorkspaceChangeOperation::Edit, &args);
+    fs::write(&path, "Inazuma\n").unwrap();
+    let first_change = first_round.finish("round-one", r#"{"ok":true}"#).unwrap();
+
+    let second_round = WorkspaceChangeRecorder::new(&session_id, Some(root.to_string_lossy().to_string()));
+    second_round.start("round-two", WorkspaceChangeOperation::Edit, &args);
+    fs::write(&path, "Fontaine\n").unwrap();
+    let second_change = second_round.finish("round-two", r#"{"ok":true}"#).unwrap();
+
+    assert_eq!(first_change.change_id, second_change.change_id);
+    assert_eq!(second_change.merged_count, 2);
+    assert_eq!(pending(&session_id).unwrap().len(), 1);
+    cancel(&session_id, &second_change.change_id).unwrap();
+    assert_eq!(fs::read_to_string(&path).unwrap(), "Mondstadt\n");
+    let _ = fs::remove_dir_all(root);
+}
+
+/// Purpose: Verify an edit followed by a move is one move record and Reject restores the original source path.
+/// Test Data: `a.txt` changes from Amber's message to Yoimiya's message before moving to `b.txt`.
+#[test]
+fn edit_then_move_merges_and_reject_restores_the_source_file() {
+    let root = temp_workspace();
+    let session_id = format!("edit-move-{}", root.file_name().unwrap().to_string_lossy());
+    fs::create_dir_all(&root).unwrap();
+    let source = root.join("a.txt");
+    let destination = root.join("b.txt");
+    fs::write(&source, "Amber is gliding.\n").unwrap();
+    let recorder = WorkspaceChangeRecorder::new(&session_id, Some(root.to_string_lossy().to_string()));
+
+    recorder.start("edit", WorkspaceChangeOperation::Edit, &serde_json::json!({ "path": "a.txt" }));
+    fs::write(&source, "Yoimiya is preparing fireworks.\n").unwrap();
+    recorder.finish("edit", r#"{"ok":true}"#).unwrap();
+    recorder.start("move", WorkspaceChangeOperation::Move, &serde_json::json!({ "src": "a.txt", "dest": "b.txt" }));
+    fs::rename(&source, &destination).unwrap();
+    let change = recorder.finish("move", r#"{"ok":true}"#).unwrap();
+
+    assert!(matches!(change.operation, WorkspaceChangeOperation::Move));
+    assert_eq!(change.source_path.as_deref(), Some("a.txt"));
+    assert_eq!(change.destination_path.as_deref(), Some("b.txt"));
+    assert_eq!(change.merged_count, 2);
+    cancel(&session_id, &change.change_id).unwrap();
+    assert_eq!(fs::read_to_string(&source).unwrap(), "Amber is gliding.\n");
+    assert!(!destination.exists());
+    let _ = fs::remove_dir_all(root);
+}
+
+/// Purpose: Verify copy is represented as one atomic record and Reject removes only the copied destination.
+/// Test Data: `traveler.txt` contains a note from Aether that is copied to `lumine.txt`.
+#[test]
+fn copy_is_one_atomic_change_and_reject_removes_the_destination() {
+    let root = temp_workspace();
+    let session_id = format!("copy-{}", root.file_name().unwrap().to_string_lossy());
+    fs::create_dir_all(&root).unwrap();
+    let source = root.join("traveler.txt");
+    let destination = root.join("lumine.txt");
+    fs::write(&source, "Aether is looking for his sibling.\n").unwrap();
+    let recorder = WorkspaceChangeRecorder::new(&session_id, Some(root.to_string_lossy().to_string()));
+
+    recorder.start("copy", WorkspaceChangeOperation::Copy, &serde_json::json!({ "src": "traveler.txt", "dest": "lumine.txt" }));
+    fs::copy(&source, &destination).unwrap();
+    let change = recorder.finish("copy", r#"{"ok":true}"#).unwrap();
+
+    assert!(matches!(change.operation, WorkspaceChangeOperation::Copy));
+    assert_eq!(change.source_path.as_deref(), Some("traveler.txt"));
+    assert_eq!(change.destination_path.as_deref(), Some("lumine.txt"));
+    assert_eq!(pending(&session_id).unwrap().len(), 1);
+    cancel(&session_id, &change.change_id).unwrap();
+    assert_eq!(fs::read_to_string(&source).unwrap(), "Aether is looking for his sibling.\n");
+    assert!(!destination.exists());
     let _ = fs::remove_dir_all(root);
 }


### PR DESCRIPTION
Workspace agent editing diff is now as follows:

**base**
1. Agent edits file, creates file, deletes file, moves file — these will be treated as **one change**.
2. One conversation and its one turn's changes (all) will be displayed in the upper user input field. The user can review all changes. For each file, the user can choose whether to accept that change or reject it. If the user rejects the change, the change will be rolled back. For editing, it will roll back to the old file content before the agent edited it; for creation, it will delete the created file; for deletion and move, it will restore the operated file.

**in one conversation but multiple turns**
1. If the user doesn't accept the file change, and the file is changed again in the next turn's edit:
   If the agent edits a sample file in multiple turns, for example:
   Given a.txt in <A state>:
   - Turn 1: agent edits a.txt, changes l8-14. <B state>
   The user isn't satisfied with the edit, the user thinks it isn't good enough, chats with the agent again to "fine-tune" the editing.
   - Turn 2: agent edits a.txt again, but changes l6-l12. <C state>
   Then the file diff will be displayed from <A state> to <C state> (not from B to C).
   And the user still doesn't accept it but rejects it, then the file should be recovered to <A state>.